### PR TITLE
run `miniwdl check` through pre-commit

### DIFF
--- a/.github/workflows/wdl-ci.yml
+++ b/.github/workflows/wdl-ci.yml
@@ -9,34 +9,22 @@ env:
   DEBIAN_FRONTEND: noninteractive
 
 jobs:
-  check:
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - name: dependencies
-        run: |
-          sudo apt-get -qq update
-          sudo apt-get -qq install shellcheck
-          pip install miniwdl
-      - uses: pre-commit/action@v1.1.0
-        with:
-          extra_args: --all-files
   linters:
     runs-on: ubuntu-18.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - uses: actions/cache@v1
         with:
           path: ~/.cache
           key: ${{runner.os}}-cache
-      - name: Run linters
+      - name: dependencies
         run: |
           source /etc/profile
           sudo apt-get -qq update
-          sudo apt-get -qq install --yes jq moreutils gettext make virtualenv zip unzip httpie git shellcheck ruby
+          sudo apt-get -qq install --yes jq moreutils make virtualenv zip unzip httpie git shellcheck
           virtualenv --python=python3.6 .venv
           source .venv/bin/activate
           pip install -r requirements-dev.txt
-          make lint
+      - uses: pre-commit/action@v1.1.0
+        with:
+          extra_args: --all-files

--- a/.github/workflows/wdl-ci.yml
+++ b/.github/workflows/wdl-ci.yml
@@ -26,4 +26,6 @@ jobs:
           source .venv/bin/activate
           pip install -r requirements-dev.txt
       - name: pre-commit
-        run: pre-commit run --all-files
+        run: |
+          source .venv/bin/activate
+          pre-commit run --all-files

--- a/.github/workflows/wdl-ci.yml
+++ b/.github/workflows/wdl-ci.yml
@@ -9,6 +9,19 @@ env:
   DEBIAN_FRONTEND: noninteractive
 
 jobs:
+  check:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: dependencies
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get -qq install shellcheck
+          pip install miniwdl
+      - uses: pre-commit/action@v1.1.0
+        with:
+          extra_args: --all-files
   linters:
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/wdl-ci.yml
+++ b/.github/workflows/wdl-ci.yml
@@ -25,7 +25,7 @@ jobs:
           virtualenv --python=python3.6 .venv
           source .venv/bin/activate
           pip install -r requirements-dev.txt
-      - name: pre-commit
+      - name: linters
         run: |
           source .venv/bin/activate
-          pre-commit run --all-files
+          make lint

--- a/.github/workflows/wdl-ci.yml
+++ b/.github/workflows/wdl-ci.yml
@@ -25,6 +25,5 @@ jobs:
           virtualenv --python=python3.6 .venv
           source .venv/bin/activate
           pip install -r requirements-dev.txt
-      - uses: pre-commit/action@v1.1.0
-        with:
-          extra_args: --all-files
+      - name: pre-commit
+        run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+- repo: local
+  hooks:
+  - id: miniwdl-check
+    name: miniwdl check
+    language: system
+    files: ".+\\.wdl"
+    verbose: true
+    entry: miniwdl
+    args: [check]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-lint:
-	find . -name '*.wdl' | xargs miniwdl check
-
 publish:
 	scripts/publish.sh
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+lint:
+	pre-commit run --all-files
+
 publish:
 	scripts/publish.sh
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 miniwdl
+pre-commit


### PR DESCRIPTION
@kislyuk [here's what it looks like](https://github.com/chanzuckerberg/idseq-workflows/runs/688600642?check_suite_focus=true) to set up `miniwdl check` through [pre-commit](https://pre-commit.com/) instead of the Makefile. In addition to the CI setup, if one has pre-commit (and miniwdl) installed locally, then `pre-commit run` in the repo checks modified .wdl files (or all .wdl files with `--all-files`) and `pre-commit install` sets that up to happen on each git commit