### PR TITLE
Port workflow conditional logic from idseq-web

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
 lint:
 	find . -name '*.wdl' | xargs miniwdl check
+
+publish:
+	scripts/publish.sh

--- a/main/host_filter.wdl
+++ b/main/host_filter.wdl
@@ -7,14 +7,10 @@ task RunValidateInput {
     String deployment_env
     String dag_branch
     String s3_wd_uri
-    # use select_all() in call from workflow
     Array[File] fastqs
-    #File fastqs_0
-    #File? fastqs_1
     Int max_input_fragments
     String file_ext
   }
-  # jq -n '$ARGS.positional' --args a b c
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
   if [[ -n "~{dag_branch}" ]]; then

--- a/main/host_filter.wdl
+++ b/main/host_filter.wdl
@@ -17,7 +17,7 @@ task RunValidateInput {
   # jq -n '$ARGS.positional' --args a b c
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -59,7 +59,7 @@ task RunStar {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -98,7 +98,7 @@ task RunTrimmomatic {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -133,7 +133,7 @@ task RunPriceSeq {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -168,7 +168,7 @@ task RunCDHitDup {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -207,7 +207,7 @@ task RunLZW {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -246,7 +246,7 @@ task RunBowtie2_bowtie2_out {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -286,7 +286,7 @@ task RunSubsample {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -328,7 +328,7 @@ task RunStarDownstream {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -367,7 +367,7 @@ task RunBowtie2_bowtie2_human_out {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -406,7 +406,7 @@ task RunGsnapFilter {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x

--- a/main/host_filter.wdl
+++ b/main/host_filter.wdl
@@ -7,9 +7,14 @@ task RunValidateInput {
     String deployment_env
     String dag_branch
     String s3_wd_uri
-    File fastqs_0
-    File? fastqs_1
+    # use select_all() in call from workflow
+    Array[File] fastqs
+    #File fastqs_0
+    #File? fastqs_1
+    Int max_input_fragments
+    String file_ext
   }
+  # jq -n '$ARGS.positional' --args a b c
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
   if ! [[ -z "~{dag_branch}" ]]; then
@@ -20,16 +25,17 @@ task RunValidateInput {
     --step-module idseq_dag.steps.run_validate_input \
     --step-class PipelineStepRunValidateInput \
     --step-name validate_input_out \
-    --input-files '[["~{fastqs_0}", "~{fastqs_1}"]]' \
-    --output-files '["validate_input_summary.json", "valid_input1.fastq", "valid_input2.fastq"]' \
+    --input-files '[["~{sep='","' fastqs}"]]' \
+    --output-files '["validate_input_summary.json", ~{if length(fastqs) == 2 then '"valid_input1.fastq", "valid_input2.fastq"' else '"valid_input1.fastq"'}]' \
     --output-dir-s3 '~{s3_wd_uri}' \
     --additional-files '{}' \
-    --additional-attributes '{"truncate_fragments_to": 75000000, "file_ext": "fastq"}'
+    --additional-attributes '{"truncate_fragments_to": ~{max_input_fragments}, "file_ext": "~{file_ext}"}'
   >>>
   output {
     File validate_input_summary_json = "validate_input_summary.json"
+    #Array[File] valid_input_fastq = select???
     File valid_input1_fastq = "valid_input1.fastq"
-    File valid_input2_fastq = "valid_input2.fastq"
+    File? valid_input2_fastq = "valid_input2.fastq"
     File? output_read_count = "validate_input_out.count"
     File? input_read_count = "fastqs.count"
   }
@@ -46,8 +52,10 @@ task RunStar {
     String dag_branch
     String s3_wd_uri
     File validate_input_summary_json
-    File valid_input1_fastq
-    File valid_input2_fastq
+    Array[File] valid_input_fastq
+    String star_genome
+    String nucleotide_type
+    String host_genome
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
@@ -59,15 +67,15 @@ task RunStar {
     --step-module idseq_dag.steps.run_star \
     --step-class PipelineStepRunStar \
     --step-name star_out \
-    --input-files '[["~{validate_input_summary_json}", "~{valid_input1_fastq}", "~{valid_input2_fastq}"]]' \
-    --output-files '["unmapped1.fastq", "unmapped2.fastq"]' \
+    --input-files '[["~{validate_input_summary_json}", "~{sep='","' valid_input_fastq}"]]' \
+    --output-files '[~{if length(valid_input_fastq) == 2 then '"unmapped1.fastq", "unmapped2.fastq"' else '"unmapped1.fastq"'}]' \
     --output-dir-s3 '~{s3_wd_uri}' \
-    --additional-files '{"star_genome": "s3://idseq-database/host_filter/mosquitos/2019-10-02/mosquito_STAR_genome.tar"}' \
-    --additional-attributes '{"output_gene_file": "reads_per_gene.star.tab", "nucleotide_type": "DNA", "host_genome": "mosquito", "output_metrics_file": "picard_insert_metrics.txt", "output_histogram_file": "insert_size_histogram.pdf"}'
+    --additional-files '{"star_genome": "~{star_genome}"}' \
+    --additional-attributes '{"output_gene_file": "reads_per_gene.star.tab", "nucleotide_type": "~{nucleotide_type}", "host_genome": "~{host_genome}", "output_metrics_file": "picard_insert_metrics.txt", "output_histogram_file": "insert_size_histogram.pdf"}'
   >>>
   output {
     File unmapped1_fastq = "unmapped1.fastq"
-    File unmapped2_fastq = "unmapped2.fastq"
+    File? unmapped2_fastq = "unmapped2.fastq"
     File? output_read_count = "star_out.count"
     File? output_gene_file = "reads_per_gene.star.tab"
     File? output_metrics_file = "picard_insert_metrics.txt"
@@ -85,8 +93,8 @@ task RunTrimmomatic {
     String deployment_env
     String dag_branch
     String s3_wd_uri
-    File unmapped1_fastq
-    File unmapped2_fastq
+    Array[File] unmapped_fastq
+    String adapter_fasta
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
@@ -98,15 +106,15 @@ task RunTrimmomatic {
     --step-module idseq_dag.steps.run_trimmomatic \
     --step-class PipelineStepRunTrimmomatic \
     --step-name trimmomatic_out \
-    --input-files '[["~{unmapped1_fastq}", "~{unmapped2_fastq}"]]' \
-    --output-files '["trimmomatic1.fastq", "trimmomatic2.fastq"]' \
+    --input-files '[["~{sep='","' unmapped_fastq}"]]' \
+    --output-files '[~{if length(unmapped_fastq) == 2 then '"trimmomatic1.fastq", "trimmomatic2.fastq"' else '"trimmomatic1.fastq"'}]' \
     --output-dir-s3 '~{s3_wd_uri}' \
-    --additional-files '{"adapter_fasta": "s3://idseq-database/adapter_sequences/illumina_TruSeq3-PE-2_NexteraPE-PE.fasta"}' \
+    --additional-files '{"adapter_fasta": "~{adapter_fasta}"}' \
     --additional-attributes '{}'
   >>>
   output {
     File trimmomatic1_fastq = "trimmomatic1.fastq"
-    File trimmomatic2_fastq = "trimmomatic2.fastq"
+    File? trimmomatic2_fastq = "trimmomatic2.fastq"
     File? output_read_count = "trimmomatic_out.count"
   }
   runtime {
@@ -121,8 +129,7 @@ task RunPriceSeq {
     String deployment_env
     String dag_branch
     String s3_wd_uri
-    File trimmomatic1_fastq
-    File trimmomatic2_fastq
+    Array[File] trimmomatic_fastq
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
@@ -134,15 +141,15 @@ task RunPriceSeq {
     --step-module idseq_dag.steps.run_priceseq \
     --step-class PipelineStepRunPriceSeq \
     --step-name priceseq_out \
-    --input-files '[["~{trimmomatic1_fastq}", "~{trimmomatic2_fastq}"]]' \
-    --output-files '["priceseq1.fa", "priceseq2.fa"]' \
+    --input-files '[["~{sep='","' trimmomatic_fastq}"]]' \
+    --output-files '[~{if length(trimmomatic_fastq) == 2 then '"priceseq1.fa", "priceseq2.fa"' else '"priceseq1.fa"'}]' \
     --output-dir-s3 '~{s3_wd_uri}' \
     --additional-files '{}' \
     --additional-attributes '{}'
   >>>
   output {
     File priceseq1_fa = "priceseq1.fa"
-    File priceseq2_fa = "priceseq2.fa"
+    File? priceseq2_fa = "priceseq2.fa"
     File? output_read_count = "priceseq_out.count"
   }
   runtime {
@@ -157,8 +164,7 @@ task RunCDHitDup {
     String deployment_env
     String dag_branch
     String s3_wd_uri
-    File priceseq1_fa
-    File priceseq2_fa
+    Array[File] priceseq_fa
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
@@ -170,15 +176,15 @@ task RunCDHitDup {
     --step-module idseq_dag.steps.run_cdhitdup \
     --step-class PipelineStepRunCDHitDup \
     --step-name cdhitdup_out \
-    --input-files '[["~{priceseq1_fa}", "~{priceseq2_fa}"]]' \
-    --output-files '["dedup1.fa", "dedup2.fa", "dedup1.fa.clstr", "cdhitdup_cluster_sizes.tsv"]' \
+    --input-files '[["~{sep='","' priceseq_fa}"]]' \
+    --output-files '[~{if length(priceseq_fa) == 2 then '"dedup1.fa", "dedup2.fa"' else '"dedup1.fa"'}, "dedup1.fa.clstr", "cdhitdup_cluster_sizes.tsv"]' \
     --output-dir-s3 '~{s3_wd_uri}' \
     --additional-files '{}' \
     --additional-attributes '{}'
   >>>
   output {
     File dedup1_fa = "dedup1.fa"
-    File dedup2_fa = "dedup2.fa"
+    File? dedup2_fa = "dedup2.fa"
     File dedup1_fa_clstr = "dedup1.fa.clstr"
     File cdhitdup_cluster_sizes_tsv = "cdhitdup_cluster_sizes.tsv"
     File? output_read_count = "cdhitdup_out.count"
@@ -195,8 +201,7 @@ task RunLZW {
     String deployment_env
     String dag_branch
     String s3_wd_uri
-    File dedup1_fa
-    File dedup2_fa
+    Array[File] dedup_fa
     File dedup1_fa_clstr
     File cdhitdup_cluster_sizes_tsv
   }
@@ -210,15 +215,15 @@ task RunLZW {
     --step-module idseq_dag.steps.run_lzw \
     --step-class PipelineStepRunLZW \
     --step-name lzw_out \
-    --input-files '[["~{dedup1_fa}", "~{dedup2_fa}", "~{dedup1_fa_clstr}", "~{cdhitdup_cluster_sizes_tsv}"]]' \
-    --output-files '["lzw1.fa", "lzw2.fa"]' \
+    --input-files '[["~{sep='","' dedup_fa}", "~{dedup1_fa_clstr}", "~{cdhitdup_cluster_sizes_tsv}"]]' \
+    --output-files '[~{if length(dedup_fa) == 2 then '"lzw1.fa", "lzw2.fa"' else '"lzw1.fa"'}]' \
     --output-dir-s3 '~{s3_wd_uri}' \
     --additional-files '{}' \
     --additional-attributes '{"thresholds": [0.45, 0.42], "threshold_readlength": 150}'
   >>>
   output {
     File lzw1_fa = "lzw1.fa"
-    File lzw2_fa = "lzw2.fa"
+    File? lzw2_fa = "lzw2.fa"
     File? output_read_count = "lzw_out.count"
   }
   runtime {
@@ -233,12 +238,11 @@ task RunBowtie2_bowtie2_out {
     String deployment_env
     String dag_branch
     String s3_wd_uri
-    File lzw1_fa
-    File lzw2_fa
-    File dedup1_fa
-    File dedup2_fa
+    Array[File] lzw_fa
+    Array[File] dedup_fa
     File dedup1_fa_clstr
     File cdhitdup_cluster_sizes_tsv
+    String bowtie2_genome
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
@@ -250,16 +254,16 @@ task RunBowtie2_bowtie2_out {
     --step-module idseq_dag.steps.run_bowtie2 \
     --step-class PipelineStepRunBowtie2 \
     --step-name bowtie2_out \
-    --input-files '[["~{lzw1_fa}", "~{lzw2_fa}"], ["~{dedup1_fa}", "~{dedup2_fa}", "~{dedup1_fa_clstr}", "~{cdhitdup_cluster_sizes_tsv}"]]' \
-    --output-files '["bowtie2_1.fa", "bowtie2_2.fa", "bowtie2_merged.fa"]' \
+    --input-files '[["~{sep='","' lzw_fa}"], ["~{sep='","' dedup_fa}", "~{dedup1_fa_clstr}", "~{cdhitdup_cluster_sizes_tsv}"]]' \
+    --output-files '[~{if length(lzw_fa) == 2 then '"bowtie2_1.fa", "bowtie2_2.fa", "bowtie2_merged.fa"' else '"bowtie2_1.fa"'}]' \
     --output-dir-s3 '~{s3_wd_uri}' \
-    --additional-files '{"bowtie2_genome": "s3://idseq-database/host_filter/mosquitos/2019-10-02/mosquito_bowtie2_genome.tar"}' \
+    --additional-files '{"bowtie2_genome": "~{bowtie2_genome}"}' \
     --additional-attributes '{"output_sam_file": "bowtie2.sam"}'
   >>>
   output {
     File bowtie2_1_fa = "bowtie2_1.fa"
-    File bowtie2_2_fa = "bowtie2_2.fa"
-    File bowtie2_merged_fa = "bowtie2_merged.fa"
+    File? bowtie2_2_fa = "bowtie2_2.fa"
+    File? bowtie2_merged_fa = "bowtie2_merged.fa"
     File? output_read_count = "bowtie2_out.count"
   }
   runtime {
@@ -274,13 +278,11 @@ task RunSubsample {
     String deployment_env
     String dag_branch
     String s3_wd_uri
-    File bowtie2_1_fa
-    File bowtie2_2_fa
-    File bowtie2_merged_fa
-    File dedup1_fa
-    File dedup2_fa
+    Array[File] bowtie2_fa
+    Array[File] dedup_fa
     File dedup1_fa_clstr
     File cdhitdup_cluster_sizes_tsv
+    Int max_subsample_fragments
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
@@ -292,16 +294,16 @@ task RunSubsample {
     --step-module idseq_dag.steps.run_subsample \
     --step-class PipelineStepRunSubsample \
     --step-name subsampled_out \
-    --input-files '[["~{bowtie2_1_fa}", "~{bowtie2_2_fa}", "~{bowtie2_merged_fa}"], ["~{dedup1_fa}", "~{dedup2_fa}", "~{dedup1_fa_clstr}", "~{cdhitdup_cluster_sizes_tsv}"]]' \
-    --output-files '["subsampled_1.fa", "subsampled_2.fa", "subsampled_merged.fa"]' \
+    --input-files '[["~{sep='","' bowtie2_fa}"], ["~{sep='","' dedup_fa}", "~{dedup1_fa_clstr}", "~{cdhitdup_cluster_sizes_tsv}"]]' \
+    --output-files '[~{if length(dedup_fa) == 2 then '"subsampled_1.fa", "subsampled_2.fa", "subsampled_merged.fa"' else '"subsampled_1.fa"'}]' \
     --output-dir-s3 '~{s3_wd_uri}' \
     --additional-files '{}' \
-    --additional-attributes '{"max_fragments": 1000000}'
+    --additional-attributes '{"max_fragments": ~{max_subsample_fragments}}'
   >>>
   output {
     File subsampled_1_fa = "subsampled_1.fa"
-    File subsampled_2_fa = "subsampled_2.fa"
-    File subsampled_merged_fa = "subsampled_merged.fa"
+    File? subsampled_2_fa = "subsampled_2.fa"
+    File? subsampled_merged_fa = "subsampled_merged.fa"
     File? output_read_count = "subsampled_out.count"
   }
   runtime {
@@ -316,16 +318,13 @@ task RunStarDownstream {
     String deployment_env
     String dag_branch
     String s3_wd_uri
-    File subsampled_1_fa
-    File subsampled_2_fa
-    File subsampled_merged_fa
+    Array[File] subsampled_fa
     File validate_input_summary_json
-    File valid_input1_fastq
-    File valid_input2_fastq
-    File dedup1_fa
-    File dedup2_fa
+    Array[File] valid_input_fastq
+    Array[File] dedup_fa
     File dedup1_fa_clstr
     File cdhitdup_cluster_sizes_tsv
+    String human_star_genome
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
@@ -337,15 +336,15 @@ task RunStarDownstream {
     --step-module idseq_dag.steps.run_star_downstream \
     --step-class PipelineStepRunStarDownstream \
     --step-name star_human_out \
-    --input-files '[["~{subsampled_1_fa}", "~{subsampled_2_fa}", "~{subsampled_merged_fa}"], ["~{validate_input_summary_json}", "~{valid_input1_fastq}", "~{valid_input2_fastq}"], ["~{dedup1_fa}", "~{dedup2_fa}", "~{dedup1_fa_clstr}", "~{cdhitdup_cluster_sizes_tsv}"]]' \
-    --output-files '["unmapped_human_1.fa", "unmapped_human_2.fa"]' \
+    --input-files '[["~{sep='","' subsampled_fa}"], ["~{validate_input_summary_json}", "~{sep='","' valid_input_fastq}"], ["~{sep='","' dedup_fa}", "~{dedup1_fa_clstr}", "~{cdhitdup_cluster_sizes_tsv}"]]' \
+    --output-files '[~{if length(dedup_fa) == 2 then '"unmapped_human_1.fa", "unmapped_human_2.fa"' else '"unmapped_human_1.fa"'}]' \
     --output-dir-s3 '~{s3_wd_uri}' \
-    --additional-files '{"star_genome": "s3://idseq-database/host_filter/human/2018-02-15-utc-1518652800-unixtime__2018-02-15-utc-1518652800-unixtime/human_STAR_genome.tar"}' \
+    --additional-files '{"star_genome": "~{human_star_genome}"}' \
     --additional-attributes '{}'
   >>>
   output {
     File unmapped_human_1_fa = "unmapped_human_1.fa"
-    File unmapped_human_2_fa = "unmapped_human_2.fa"
+    File? unmapped_human_2_fa = "unmapped_human_2.fa"
     File? output_read_count = "star_human_out.count"
   }
   runtime {
@@ -360,12 +359,11 @@ task RunBowtie2_bowtie2_human_out {
     String deployment_env
     String dag_branch
     String s3_wd_uri
-    File unmapped_human_1_fa
-    File unmapped_human_2_fa
-    File dedup1_fa
-    File dedup2_fa
+    Array[File] unmapped_human_fa
+    Array[File] dedup_fa
     File dedup1_fa_clstr
     File cdhitdup_cluster_sizes_tsv
+    String human_bowtie2_genome
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
@@ -377,16 +375,16 @@ task RunBowtie2_bowtie2_human_out {
     --step-module idseq_dag.steps.run_bowtie2 \
     --step-class PipelineStepRunBowtie2 \
     --step-name bowtie2_human_out \
-    --input-files '[["~{unmapped_human_1_fa}", "~{unmapped_human_2_fa}"], ["~{dedup1_fa}", "~{dedup2_fa}", "~{dedup1_fa_clstr}", "~{cdhitdup_cluster_sizes_tsv}"]]' \
-    --output-files '["bowtie2_human_1.fa", "bowtie2_human_2.fa", "bowtie2_human_merged.fa"]' \
+    --input-files '[["~{sep='","' unmapped_human_fa}"], ["~{sep='","' dedup_fa}", "~{dedup1_fa_clstr}", "~{cdhitdup_cluster_sizes_tsv}"]]' \
+    --output-files '[~{if length(dedup_fa) == 2 then '"bowtie2_human_1.fa", "bowtie2_human_2.fa", "bowtie2_human_merged.fa"' else '"bowtie2_human_1.fa"'}]' \
     --output-dir-s3 '~{s3_wd_uri}' \
-    --additional-files '{"bowtie2_genome": "s3://idseq-database/host_filter/human/2018-02-15-utc-1518652800-unixtime__2018-02-15-utc-1518652800-unixtime/human_bowtie2_genome.tar"}' \
+    --additional-files '{"bowtie2_genome": "~{human_bowtie2_genome}"}' \
     --additional-attributes '{"output_sam_file": "bowtie2_human.sam"}'
   >>>
   output {
     File bowtie2_human_1_fa = "bowtie2_human_1.fa"
-    File bowtie2_human_2_fa = "bowtie2_human_2.fa"
-    File bowtie2_human_merged_fa = "bowtie2_human_merged.fa"
+    File? bowtie2_human_2_fa = "bowtie2_human_2.fa"
+    File? bowtie2_human_merged_fa = "bowtie2_human_merged.fa"
     File? output_read_count = "bowtie2_human_out.count"
   }
   runtime {
@@ -401,11 +399,8 @@ task RunGsnapFilter {
     String deployment_env
     String dag_branch
     String s3_wd_uri
-    File bowtie2_human_1_fa
-    File bowtie2_human_2_fa
-    File bowtie2_human_merged_fa
-    File dedup1_fa
-    File dedup2_fa
+    Array[File] subsampled_fa
+    Array[File] dedup_fa
     File dedup1_fa_clstr
     File cdhitdup_cluster_sizes_tsv
   }
@@ -419,16 +414,16 @@ task RunGsnapFilter {
     --step-module idseq_dag.steps.run_gsnap_filter \
     --step-class PipelineStepRunGsnapFilter \
     --step-name gsnap_filter_out \
-    --input-files '[["~{bowtie2_human_1_fa}", "~{bowtie2_human_2_fa}", "~{bowtie2_human_merged_fa}"], ["~{dedup1_fa}", "~{dedup2_fa}", "~{dedup1_fa_clstr}", "~{cdhitdup_cluster_sizes_tsv}"]]' \
-    --output-files '["gsnap_filter_1.fa", "gsnap_filter_2.fa", "gsnap_filter_merged.fa"]' \
+    --input-files '[["~{sep='","' subsampled_fa}"], ["~{sep='","' dedup_fa}", "~{dedup1_fa_clstr}", "~{cdhitdup_cluster_sizes_tsv}"]]' \
+    --output-files '[~{if length(dedup_fa) == 2 then '"gsnap_filter_1.fa", "gsnap_filter_2.fa", "gsnap_filter_merged.fa"' else '"gsnap_filter_1.fa"'}]' \
     --output-dir-s3 '~{s3_wd_uri}' \
     --additional-files '{"gsnap_genome": "s3://idseq-database/host_filter/human/2018-02-15-utc-1518652800-unixtime__2018-02-15-utc-1518652800-unixtime/hg38_pantro5_k16.tar"}' \
     --additional-attributes '{"output_sam_file": "gsnap_filter.sam"}'
   >>>
   output {
     File gsnap_filter_1_fa = "gsnap_filter_1.fa"
-    File gsnap_filter_2_fa = "gsnap_filter_2.fa"
-    File gsnap_filter_merged_fa = "gsnap_filter_merged.fa"
+    File? gsnap_filter_2_fa = "gsnap_filter_2.fa"
+    File? gsnap_filter_merged_fa = "gsnap_filter_merged.fa"
     File? output_read_count = "gsnap_filter_out.count"
   }
   runtime {
@@ -445,6 +440,16 @@ workflow idseq_host_filter {
     String s3_wd_uri
     File fastqs_0
     File? fastqs_1
+    String file_ext
+    String nucleotide_type
+    String host_genome
+    String adapter_fasta
+    String star_genome
+    String bowtie2_genome
+    String human_star_genome
+    String human_bowtie2_genome
+    Int max_input_fragments
+    Int max_subsample_fragments
   }
 
   call RunValidateInput {
@@ -454,8 +459,9 @@ workflow idseq_host_filter {
       deployment_env = deployment_env,
       dag_branch = dag_branch,
       s3_wd_uri = s3_wd_uri,
-      fastqs_0 = fastqs_0,
-      fastqs_1 = fastqs_1
+      fastqs = select_all([fastqs_0, fastqs_1]),
+      file_ext = file_ext,
+      max_input_fragments = max_input_fragments
   }
 
   call RunStar {
@@ -466,8 +472,10 @@ workflow idseq_host_filter {
       dag_branch = dag_branch,
       s3_wd_uri = s3_wd_uri,
       validate_input_summary_json = RunValidateInput.validate_input_summary_json,
-      valid_input1_fastq = RunValidateInput.valid_input1_fastq,
-      valid_input2_fastq = RunValidateInput.valid_input2_fastq
+      valid_input_fastq = select_all([RunValidateInput.valid_input1_fastq, RunValidateInput.valid_input2_fastq]),
+      star_genome = star_genome,
+      nucleotide_type = nucleotide_type,
+      host_genome = host_genome
   }
 
   call RunTrimmomatic {
@@ -477,8 +485,8 @@ workflow idseq_host_filter {
       deployment_env = deployment_env,
       dag_branch = dag_branch,
       s3_wd_uri = s3_wd_uri,
-      unmapped1_fastq = RunStar.unmapped1_fastq,
-      unmapped2_fastq = RunStar.unmapped2_fastq
+      unmapped_fastq = select_all([RunStar.unmapped1_fastq, RunStar.unmapped2_fastq]),
+      adapter_fasta = adapter_fasta
   }
 
   call RunPriceSeq {
@@ -488,8 +496,7 @@ workflow idseq_host_filter {
       deployment_env = deployment_env,
       dag_branch = dag_branch,
       s3_wd_uri = s3_wd_uri,
-      trimmomatic1_fastq = RunTrimmomatic.trimmomatic1_fastq,
-      trimmomatic2_fastq = RunTrimmomatic.trimmomatic2_fastq
+      trimmomatic_fastq = select_all([RunTrimmomatic.trimmomatic1_fastq, RunTrimmomatic.trimmomatic2_fastq])
   }
 
   call RunCDHitDup {
@@ -499,8 +506,7 @@ workflow idseq_host_filter {
       deployment_env = deployment_env,
       dag_branch = dag_branch,
       s3_wd_uri = s3_wd_uri,
-      priceseq1_fa = RunPriceSeq.priceseq1_fa,
-      priceseq2_fa = RunPriceSeq.priceseq2_fa
+      priceseq_fa = select_all([RunPriceSeq.priceseq1_fa, RunPriceSeq.priceseq2_fa])
   }
 
   call RunLZW {
@@ -510,8 +516,7 @@ workflow idseq_host_filter {
       deployment_env = deployment_env,
       dag_branch = dag_branch,
       s3_wd_uri = s3_wd_uri,
-      dedup1_fa = RunCDHitDup.dedup1_fa,
-      dedup2_fa = RunCDHitDup.dedup2_fa,
+      dedup_fa = select_all([RunCDHitDup.dedup1_fa, RunCDHitDup.dedup2_fa]),
       dedup1_fa_clstr = RunCDHitDup.dedup1_fa_clstr,
       cdhitdup_cluster_sizes_tsv = RunCDHitDup.cdhitdup_cluster_sizes_tsv
   }
@@ -523,12 +528,11 @@ workflow idseq_host_filter {
       deployment_env = deployment_env,
       dag_branch = dag_branch,
       s3_wd_uri = s3_wd_uri,
-      lzw1_fa = RunLZW.lzw1_fa,
-      lzw2_fa = RunLZW.lzw2_fa,
-      dedup1_fa = RunCDHitDup.dedup1_fa,
-      dedup2_fa = RunCDHitDup.dedup2_fa,
+      lzw_fa = select_all([RunLZW.lzw1_fa, RunLZW.lzw2_fa]),
+      dedup_fa = select_all([RunCDHitDup.dedup1_fa, RunCDHitDup.dedup2_fa]),
       dedup1_fa_clstr = RunCDHitDup.dedup1_fa_clstr,
-      cdhitdup_cluster_sizes_tsv = RunCDHitDup.cdhitdup_cluster_sizes_tsv
+      cdhitdup_cluster_sizes_tsv = RunCDHitDup.cdhitdup_cluster_sizes_tsv,
+      bowtie2_genome = bowtie2_genome
   }
 
   call RunSubsample {
@@ -538,48 +542,48 @@ workflow idseq_host_filter {
       deployment_env = deployment_env,
       dag_branch = dag_branch,
       s3_wd_uri = s3_wd_uri,
-      bowtie2_1_fa = RunBowtie2_bowtie2_out.bowtie2_1_fa,
-      bowtie2_2_fa = RunBowtie2_bowtie2_out.bowtie2_2_fa,
-      bowtie2_merged_fa = RunBowtie2_bowtie2_out.bowtie2_merged_fa,
-      dedup1_fa = RunCDHitDup.dedup1_fa,
-      dedup2_fa = RunCDHitDup.dedup2_fa,
+      bowtie2_fa = select_all([RunBowtie2_bowtie2_out.bowtie2_1_fa, RunBowtie2_bowtie2_out.bowtie2_2_fa, RunBowtie2_bowtie2_out.bowtie2_merged_fa]),
+      dedup_fa = select_all([RunCDHitDup.dedup1_fa, RunCDHitDup.dedup2_fa]),
       dedup1_fa_clstr = RunCDHitDup.dedup1_fa_clstr,
-      cdhitdup_cluster_sizes_tsv = RunCDHitDup.cdhitdup_cluster_sizes_tsv
+      cdhitdup_cluster_sizes_tsv = RunCDHitDup.cdhitdup_cluster_sizes_tsv,
+      max_subsample_fragments = max_subsample_fragments
   }
 
-  call RunStarDownstream {
-    input:
-      docker_image_id = docker_image_id,
-      aws_region = aws_region,
-      deployment_env = deployment_env,
-      dag_branch = dag_branch,
-      s3_wd_uri = s3_wd_uri,
-      subsampled_1_fa = RunSubsample.subsampled_1_fa,
-      subsampled_2_fa = RunSubsample.subsampled_2_fa,
-      subsampled_merged_fa = RunSubsample.subsampled_merged_fa,
-      validate_input_summary_json = RunValidateInput.validate_input_summary_json,
-      valid_input1_fastq = RunValidateInput.valid_input1_fastq,
-      valid_input2_fastq = RunValidateInput.valid_input2_fastq,
-      dedup1_fa = RunCDHitDup.dedup1_fa,
-      dedup2_fa = RunCDHitDup.dedup2_fa,
-      dedup1_fa_clstr = RunCDHitDup.dedup1_fa_clstr,
-      cdhitdup_cluster_sizes_tsv = RunCDHitDup.cdhitdup_cluster_sizes_tsv
+  if (host_genome != "human") {
+    call RunStarDownstream {
+      input:
+        docker_image_id = docker_image_id,
+        aws_region = aws_region,
+        deployment_env = deployment_env,
+        dag_branch = dag_branch,
+        s3_wd_uri = s3_wd_uri,
+        subsampled_fa = select_all([RunSubsample.subsampled_1_fa, RunSubsample.subsampled_2_fa, RunSubsample.subsampled_merged_fa]),
+        validate_input_summary_json = RunValidateInput.validate_input_summary_json,
+        valid_input_fastq = select_all([RunValidateInput.valid_input1_fastq, RunValidateInput.valid_input2_fastq]),
+        dedup_fa = select_all([RunCDHitDup.dedup1_fa, RunCDHitDup.dedup2_fa]),
+        dedup1_fa_clstr = RunCDHitDup.dedup1_fa_clstr,
+        cdhitdup_cluster_sizes_tsv = RunCDHitDup.cdhitdup_cluster_sizes_tsv,
+        human_star_genome = human_star_genome
+    }
+
+    call RunBowtie2_bowtie2_human_out {
+      input:
+        docker_image_id = docker_image_id,
+        aws_region = aws_region,
+        deployment_env = deployment_env,
+        dag_branch = dag_branch,
+        s3_wd_uri = s3_wd_uri,
+        unmapped_human_fa = select_all([RunStarDownstream.unmapped_human_1_fa, RunStarDownstream.unmapped_human_2_fa]),
+        dedup_fa = select_all([RunCDHitDup.dedup1_fa, RunCDHitDup.dedup2_fa]),
+        dedup1_fa_clstr = RunCDHitDup.dedup1_fa_clstr,
+        cdhitdup_cluster_sizes_tsv = RunCDHitDup.cdhitdup_cluster_sizes_tsv,
+        human_bowtie2_genome = human_bowtie2_genome
+    }
   }
 
-  call RunBowtie2_bowtie2_human_out {
-    input:
-      docker_image_id = docker_image_id,
-      aws_region = aws_region,
-      deployment_env = deployment_env,
-      dag_branch = dag_branch,
-      s3_wd_uri = s3_wd_uri,
-      unmapped_human_1_fa = RunStarDownstream.unmapped_human_1_fa,
-      unmapped_human_2_fa = RunStarDownstream.unmapped_human_2_fa,
-      dedup1_fa = RunCDHitDup.dedup1_fa,
-      dedup2_fa = RunCDHitDup.dedup2_fa,
-      dedup1_fa_clstr = RunCDHitDup.dedup1_fa_clstr,
-      cdhitdup_cluster_sizes_tsv = RunCDHitDup.cdhitdup_cluster_sizes_tsv
-  }
+  Array[File] gsnap_filter_input = if (host_genome == "human")
+    then select_all([RunSubsample.subsampled_1_fa, RunSubsample.subsampled_2_fa, RunSubsample.subsampled_merged_fa])
+    else select_all([RunBowtie2_bowtie2_human_out.bowtie2_human_1_fa, RunBowtie2_bowtie2_human_out.bowtie2_human_2_fa, RunBowtie2_bowtie2_human_out.bowtie2_human_merged_fa])
 
   call RunGsnapFilter {
     input:
@@ -588,11 +592,8 @@ workflow idseq_host_filter {
       deployment_env = deployment_env,
       dag_branch = dag_branch,
       s3_wd_uri = s3_wd_uri,
-      bowtie2_human_1_fa = RunBowtie2_bowtie2_human_out.bowtie2_human_1_fa,
-      bowtie2_human_2_fa = RunBowtie2_bowtie2_human_out.bowtie2_human_2_fa,
-      bowtie2_human_merged_fa = RunBowtie2_bowtie2_human_out.bowtie2_human_merged_fa,
-      dedup1_fa = RunCDHitDup.dedup1_fa,
-      dedup2_fa = RunCDHitDup.dedup2_fa,
+      subsampled_fa = gsnap_filter_input,
+      dedup_fa = select_all([RunCDHitDup.dedup1_fa, RunCDHitDup.dedup2_fa]),
       dedup1_fa_clstr = RunCDHitDup.dedup1_fa_clstr,
       cdhitdup_cluster_sizes_tsv = RunCDHitDup.cdhitdup_cluster_sizes_tsv
   }
@@ -600,43 +601,43 @@ workflow idseq_host_filter {
   output {
     File validate_input_out_validate_input_summary_json = RunValidateInput.validate_input_summary_json
     File validate_input_out_valid_input1_fastq = RunValidateInput.valid_input1_fastq
-    File validate_input_out_valid_input2_fastq = RunValidateInput.valid_input2_fastq
+    File? validate_input_out_valid_input2_fastq = RunValidateInput.valid_input2_fastq
     File? validate_input_out_count = RunValidateInput.output_read_count
     File star_out_unmapped1_fastq = RunStar.unmapped1_fastq
-    File star_out_unmapped2_fastq = RunStar.unmapped2_fastq
+    File? star_out_unmapped2_fastq = RunStar.unmapped2_fastq
     File? star_out_count = RunStar.output_read_count
     File trimmomatic_out_trimmomatic1_fastq = RunTrimmomatic.trimmomatic1_fastq
-    File trimmomatic_out_trimmomatic2_fastq = RunTrimmomatic.trimmomatic2_fastq
+    File? trimmomatic_out_trimmomatic2_fastq = RunTrimmomatic.trimmomatic2_fastq
     File? trimmomatic_out_count = RunTrimmomatic.output_read_count
     File priceseq_out_priceseq1_fa = RunPriceSeq.priceseq1_fa
-    File priceseq_out_priceseq2_fa = RunPriceSeq.priceseq2_fa
+    File? priceseq_out_priceseq2_fa = RunPriceSeq.priceseq2_fa
     File? priceseq_out_count = RunPriceSeq.output_read_count
     File cdhitdup_out_dedup1_fa = RunCDHitDup.dedup1_fa
-    File cdhitdup_out_dedup2_fa = RunCDHitDup.dedup2_fa
+    File? cdhitdup_out_dedup2_fa = RunCDHitDup.dedup2_fa
     File cdhitdup_out_dedup1_fa_clstr = RunCDHitDup.dedup1_fa_clstr
     File cdhitdup_out_cdhitdup_cluster_sizes_tsv = RunCDHitDup.cdhitdup_cluster_sizes_tsv
     File? cdhitdup_out_count = RunCDHitDup.output_read_count
     File lzw_out_lzw1_fa = RunLZW.lzw1_fa
-    File lzw_out_lzw2_fa = RunLZW.lzw2_fa
+    File? lzw_out_lzw2_fa = RunLZW.lzw2_fa
     File? lzw_out_count = RunLZW.output_read_count
     File bowtie2_out_bowtie2_1_fa = RunBowtie2_bowtie2_out.bowtie2_1_fa
-    File bowtie2_out_bowtie2_2_fa = RunBowtie2_bowtie2_out.bowtie2_2_fa
-    File bowtie2_out_bowtie2_merged_fa = RunBowtie2_bowtie2_out.bowtie2_merged_fa
+    File? bowtie2_out_bowtie2_2_fa = RunBowtie2_bowtie2_out.bowtie2_2_fa
+    File? bowtie2_out_bowtie2_merged_fa = RunBowtie2_bowtie2_out.bowtie2_merged_fa
     File? bowtie2_out_count = RunBowtie2_bowtie2_out.output_read_count
     File subsampled_out_subsampled_1_fa = RunSubsample.subsampled_1_fa
-    File subsampled_out_subsampled_2_fa = RunSubsample.subsampled_2_fa
-    File subsampled_out_subsampled_merged_fa = RunSubsample.subsampled_merged_fa
+    File? subsampled_out_subsampled_2_fa = RunSubsample.subsampled_2_fa
+    File? subsampled_out_subsampled_merged_fa = RunSubsample.subsampled_merged_fa
     File? subsampled_out_count = RunSubsample.output_read_count
-    File star_human_out_unmapped_human_1_fa = RunStarDownstream.unmapped_human_1_fa
-    File star_human_out_unmapped_human_2_fa = RunStarDownstream.unmapped_human_2_fa
+    File? star_human_out_unmapped_human_1_fa = RunStarDownstream.unmapped_human_1_fa
+    File? star_human_out_unmapped_human_2_fa = RunStarDownstream.unmapped_human_2_fa
     File? star_human_out_count = RunStarDownstream.output_read_count
-    File bowtie2_human_out_bowtie2_human_1_fa = RunBowtie2_bowtie2_human_out.bowtie2_human_1_fa
-    File bowtie2_human_out_bowtie2_human_2_fa = RunBowtie2_bowtie2_human_out.bowtie2_human_2_fa
-    File bowtie2_human_out_bowtie2_human_merged_fa = RunBowtie2_bowtie2_human_out.bowtie2_human_merged_fa
+    File? bowtie2_human_out_bowtie2_human_1_fa = RunBowtie2_bowtie2_human_out.bowtie2_human_1_fa
+    File? bowtie2_human_out_bowtie2_human_2_fa = RunBowtie2_bowtie2_human_out.bowtie2_human_2_fa
+    File? bowtie2_human_out_bowtie2_human_merged_fa = RunBowtie2_bowtie2_human_out.bowtie2_human_merged_fa
     File? bowtie2_human_out_count = RunBowtie2_bowtie2_human_out.output_read_count
     File gsnap_filter_out_gsnap_filter_1_fa = RunGsnapFilter.gsnap_filter_1_fa
-    File gsnap_filter_out_gsnap_filter_2_fa = RunGsnapFilter.gsnap_filter_2_fa
-    File gsnap_filter_out_gsnap_filter_merged_fa = RunGsnapFilter.gsnap_filter_merged_fa
+    File? gsnap_filter_out_gsnap_filter_2_fa = RunGsnapFilter.gsnap_filter_2_fa
+    File? gsnap_filter_out_gsnap_filter_merged_fa = RunGsnapFilter.gsnap_filter_merged_fa
     File? gsnap_filter_out_count = RunGsnapFilter.output_read_count
     File? input_read_count = RunValidateInput.input_read_count
     File? output_gene_file = RunStar.output_gene_file

--- a/main/host_filter.wdl
+++ b/main/host_filter.wdl
@@ -29,7 +29,6 @@ task RunValidateInput {
   >>>
   output {
     File validate_input_summary_json = "validate_input_summary.json"
-    #Array[File] valid_input_fastq = select???
     File valid_input1_fastq = "valid_input1.fastq"
     File? valid_input2_fastq = "valid_input2.fastq"
     File? output_read_count = "validate_input_out.count"

--- a/main/non_host_alignment.wdl
+++ b/main/non_host_alignment.wdl
@@ -7,9 +7,7 @@ task RunAlignmentRemotely_gsnap_out {
     String deployment_env
     String dag_branch
     String s3_wd_uri
-    File host_filter_out_gsnap_filter_1_fa
-    File host_filter_out_gsnap_filter_2_fa
-    File host_filter_out_gsnap_filter_merged_fa
+    Array[File] host_filter_out_gsnap_filter_fa
     File cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
     String lineage_db
     String accession2taxid_db
@@ -18,7 +16,7 @@ task RunAlignmentRemotely_gsnap_out {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -26,7 +24,7 @@ task RunAlignmentRemotely_gsnap_out {
     --step-module idseq_dag.steps.run_alignment_remotely \
     --step-class PipelineStepRunAlignmentRemotely \
     --step-name gsnap_out \
-    --input-files '[["~{host_filter_out_gsnap_filter_1_fa}", "~{host_filter_out_gsnap_filter_2_fa}", "~{host_filter_out_gsnap_filter_merged_fa}"], ["~{cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv}"]]' \
+    --input-files '[["~{sep='","' host_filter_out_gsnap_filter_fa}"], ["~{cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv}"]]' \
     --output-files '["gsnap.m8", "gsnap.deduped.m8", "gsnap.hitsummary.tab", "gsnap_counts_with_dcr.json"]' \
     --output-dir-s3 '~{s3_wd_uri}' \
     --additional-files '{"lineage_db": "~{lineage_db}", "accession2taxid_db": "~{accession2taxid_db}", "taxon_blacklist": "~{taxon_blacklist}"}' \
@@ -51,9 +49,7 @@ task RunAlignmentRemotely_rapsearch2_out {
     String deployment_env
     String dag_branch
     String s3_wd_uri
-    File host_filter_out_gsnap_filter_1_fa
-    File host_filter_out_gsnap_filter_2_fa
-    File host_filter_out_gsnap_filter_merged_fa
+    Array[File] host_filter_out_gsnap_filter_fa
     File cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
     String lineage_db
     String accession2taxid_db
@@ -62,7 +58,7 @@ task RunAlignmentRemotely_rapsearch2_out {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -70,7 +66,7 @@ task RunAlignmentRemotely_rapsearch2_out {
     --step-module idseq_dag.steps.run_alignment_remotely \
     --step-class PipelineStepRunAlignmentRemotely \
     --step-name rapsearch2_out \
-    --input-files '[["~{host_filter_out_gsnap_filter_1_fa}", "~{host_filter_out_gsnap_filter_2_fa}", "~{host_filter_out_gsnap_filter_merged_fa}"], ["~{cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv}"]]' \
+    --input-files '[["~{sep='","' host_filter_out_gsnap_filter_fa}"], ["~{cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv}"]]' \
     --output-files '["rapsearch2.m8", "rapsearch2.deduped.m8", "rapsearch2.hitsummary.tab", "rapsearch2_counts_with_dcr.json"]' \
     --output-dir-s3 '~{s3_wd_uri}' \
     --additional-files '{"lineage_db": "~{lineage_db}", "accession2taxid_db": "~{accession2taxid_db}", "taxon_blacklist": "~{taxon_blacklist}"}' \
@@ -106,7 +102,7 @@ task CombineTaxonCounts {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -136,9 +132,7 @@ task GenerateAnnotatedFasta {
     String deployment_env
     String dag_branch
     String s3_wd_uri
-    File host_filter_out_gsnap_filter_1_fa
-    File host_filter_out_gsnap_filter_2_fa
-    File host_filter_out_gsnap_filter_merged_fa
+    Array[File] host_filter_out_gsnap_filter_fa
     File gsnap_m8
     File gsnap_deduped_m8
     File gsnap_hitsummary_tab
@@ -153,7 +147,7 @@ task GenerateAnnotatedFasta {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -161,7 +155,7 @@ task GenerateAnnotatedFasta {
     --step-module idseq_dag.steps.generate_annotated_fasta \
     --step-class PipelineStepGenerateAnnotatedFasta \
     --step-name annotated_out \
-    --input-files '[["~{host_filter_out_gsnap_filter_1_fa}", "~{host_filter_out_gsnap_filter_2_fa}", "~{host_filter_out_gsnap_filter_merged_fa}"], ["~{gsnap_m8}", "~{gsnap_deduped_m8}", "~{gsnap_hitsummary_tab}", "~{gsnap_counts_with_dcr_json}"], ["~{rapsearch2_m8}", "~{rapsearch2_deduped_m8}", "~{rapsearch2_hitsummary_tab}", "~{rapsearch2_counts_with_dcr_json}"], ["~{cdhitdup_out_dedup1_fa_clstr}", "~{cdhitdup_out_dedup1_fa}"], ["~{cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv}"]]' \
+    --input-files '[["~{sep='","' host_filter_out_gsnap_filter_fa}"], ["~{gsnap_m8}", "~{gsnap_deduped_m8}", "~{gsnap_hitsummary_tab}", "~{gsnap_counts_with_dcr_json}"], ["~{rapsearch2_m8}", "~{rapsearch2_deduped_m8}", "~{rapsearch2_hitsummary_tab}", "~{rapsearch2_counts_with_dcr_json}"], ["~{cdhitdup_out_dedup1_fa_clstr}", "~{cdhitdup_out_dedup1_fa}"], ["~{cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv}"]]' \
     --output-files '["annotated_merged.fa", "unidentified.fa"]' \
     --output-dir-s3 '~{s3_wd_uri}' \
     --additional-files '{}' \
@@ -185,8 +179,8 @@ workflow idseq_non_host_alignment {
     String dag_branch
     String s3_wd_uri
     File host_filter_out_gsnap_filter_1_fa
-    File host_filter_out_gsnap_filter_2_fa
-    File host_filter_out_gsnap_filter_merged_fa
+    File? host_filter_out_gsnap_filter_2_fa
+    File? host_filter_out_gsnap_filter_merged_fa
     File cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
     File cdhitdup_out_dedup1_fa_clstr
     File cdhitdup_out_dedup1_fa
@@ -203,9 +197,7 @@ workflow idseq_non_host_alignment {
       deployment_env = deployment_env,
       dag_branch = dag_branch,
       s3_wd_uri = s3_wd_uri,
-      host_filter_out_gsnap_filter_1_fa = host_filter_out_gsnap_filter_1_fa,
-      host_filter_out_gsnap_filter_2_fa = host_filter_out_gsnap_filter_2_fa,
-      host_filter_out_gsnap_filter_merged_fa = host_filter_out_gsnap_filter_merged_fa,
+      host_filter_out_gsnap_filter_fa = select_all([host_filter_out_gsnap_filter_1_fa, host_filter_out_gsnap_filter_2_fa, host_filter_out_gsnap_filter_merged_fa]),
       cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv = cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv,
       lineage_db = lineage_db,
       accession2taxid_db = accession2taxid_db,
@@ -220,9 +212,7 @@ workflow idseq_non_host_alignment {
       deployment_env = deployment_env,
       dag_branch = dag_branch,
       s3_wd_uri = s3_wd_uri,
-      host_filter_out_gsnap_filter_1_fa = host_filter_out_gsnap_filter_1_fa,
-      host_filter_out_gsnap_filter_2_fa = host_filter_out_gsnap_filter_2_fa,
-      host_filter_out_gsnap_filter_merged_fa = host_filter_out_gsnap_filter_merged_fa,
+      host_filter_out_gsnap_filter_fa = select_all([host_filter_out_gsnap_filter_1_fa, host_filter_out_gsnap_filter_2_fa, host_filter_out_gsnap_filter_merged_fa]),
       cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv = cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv,
       lineage_db = lineage_db,
       accession2taxid_db = accession2taxid_db,
@@ -254,9 +244,7 @@ workflow idseq_non_host_alignment {
       deployment_env = deployment_env,
       dag_branch = dag_branch,
       s3_wd_uri = s3_wd_uri,
-      host_filter_out_gsnap_filter_1_fa = host_filter_out_gsnap_filter_1_fa,
-      host_filter_out_gsnap_filter_2_fa = host_filter_out_gsnap_filter_2_fa,
-      host_filter_out_gsnap_filter_merged_fa = host_filter_out_gsnap_filter_merged_fa,
+      host_filter_out_gsnap_filter_fa = select_all([host_filter_out_gsnap_filter_1_fa, host_filter_out_gsnap_filter_2_fa, host_filter_out_gsnap_filter_merged_fa]),
       gsnap_m8 = RunAlignmentRemotely_gsnap_out.gsnap_m8,
       gsnap_deduped_m8 = RunAlignmentRemotely_gsnap_out.gsnap_deduped_m8,
       gsnap_hitsummary_tab = RunAlignmentRemotely_gsnap_out.gsnap_hitsummary_tab,

--- a/main/non_host_alignment.wdl
+++ b/main/non_host_alignment.wdl
@@ -12,7 +12,9 @@ task RunAlignmentRemotely_gsnap_out {
     String lineage_db
     String accession2taxid_db
     String taxon_blacklist
+    String? deuterostome_db
     String index_dir_suffix
+    Boolean use_taxon_whitelist
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
@@ -27,8 +29,8 @@ task RunAlignmentRemotely_gsnap_out {
     --input-files '[["~{sep='","' host_filter_out_gsnap_filter_fa}"], ["~{cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv}"]]' \
     --output-files '["gsnap.m8", "gsnap.deduped.m8", "gsnap.hitsummary.tab", "gsnap_counts_with_dcr.json"]' \
     --output-dir-s3 '~{s3_wd_uri}' \
-    --additional-files '{"lineage_db": "~{lineage_db}", "accession2taxid_db": "~{accession2taxid_db}", "taxon_blacklist": "~{taxon_blacklist}"}' \
-    --additional-attributes '{"alignment_algorithm": "gsnap", "index_dir_suffix": "~{index_dir_suffix}"}'
+    --additional-files '{"lineage_db": "~{lineage_db}", "accession2taxid_db": "~{accession2taxid_db}", "taxon_blacklist": "~{taxon_blacklist}", "deuterostome_db": "~{deuterostome_db}"}' \
+    --additional-attributes '{"alignment_algorithm": "gsnap", "index_dir_suffix": "~{index_dir_suffix}", "use_taxon_whitelist": "~{use_taxon_whitelist}"}'
   >>>
   output {
     File gsnap_m8 = "gsnap.m8"
@@ -55,6 +57,7 @@ task RunAlignmentRemotely_rapsearch2_out {
     String accession2taxid_db
     String taxon_blacklist
     String index_dir_suffix
+    Boolean use_taxon_whitelist
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
@@ -70,7 +73,7 @@ task RunAlignmentRemotely_rapsearch2_out {
     --output-files '["rapsearch2.m8", "rapsearch2.deduped.m8", "rapsearch2.hitsummary.tab", "rapsearch2_counts_with_dcr.json"]' \
     --output-dir-s3 '~{s3_wd_uri}' \
     --additional-files '{"lineage_db": "~{lineage_db}", "accession2taxid_db": "~{accession2taxid_db}", "taxon_blacklist": "~{taxon_blacklist}"}' \
-    --additional-attributes '{"alignment_algorithm": "rapsearch2", "index_dir_suffix": "~{index_dir_suffix}"}'
+    --additional-attributes '{"alignment_algorithm": "rapsearch2", "index_dir_suffix": "~{index_dir_suffix}", "use_taxon_whitelist": "~{use_taxon_whitelist}"}'
   >>>
   output {
     File rapsearch2_m8 = "rapsearch2.m8"
@@ -188,6 +191,8 @@ workflow idseq_non_host_alignment {
     String accession2taxid_db
     String taxon_blacklist
     String index_dir_suffix
+    String? deuterostome_db
+    Boolean use_taxon_whitelist
   }
 
   call RunAlignmentRemotely_gsnap_out {
@@ -202,7 +207,9 @@ workflow idseq_non_host_alignment {
       lineage_db = lineage_db,
       accession2taxid_db = accession2taxid_db,
       taxon_blacklist = taxon_blacklist,
-      index_dir_suffix = index_dir_suffix
+      deuterostome_db = deuterostome_db,
+      index_dir_suffix = index_dir_suffix,
+      use_taxon_whitelist = use_taxon_whitelist
   }
 
   call RunAlignmentRemotely_rapsearch2_out {
@@ -217,7 +224,8 @@ workflow idseq_non_host_alignment {
       lineage_db = lineage_db,
       accession2taxid_db = accession2taxid_db,
       taxon_blacklist = taxon_blacklist,
-      index_dir_suffix = index_dir_suffix
+      index_dir_suffix = index_dir_suffix,
+      use_taxon_whitelist = use_taxon_whitelist
   }
 
   call CombineTaxonCounts {

--- a/main/non_host_alignment.wdl
+++ b/main/non_host_alignment.wdl
@@ -11,6 +11,10 @@ task RunAlignmentRemotely_gsnap_out {
     File host_filter_out_gsnap_filter_2_fa
     File host_filter_out_gsnap_filter_merged_fa
     File cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
+    String lineage_db
+    String accession2taxid_db
+    String taxon_blacklist
+    String index_dir_suffix
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
@@ -25,8 +29,8 @@ task RunAlignmentRemotely_gsnap_out {
     --input-files '[["~{host_filter_out_gsnap_filter_1_fa}", "~{host_filter_out_gsnap_filter_2_fa}", "~{host_filter_out_gsnap_filter_merged_fa}"], ["~{cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv}"]]' \
     --output-files '["gsnap.m8", "gsnap.deduped.m8", "gsnap.hitsummary.tab", "gsnap_counts_with_dcr.json"]' \
     --output-dir-s3 '~{s3_wd_uri}' \
-    --additional-files '{"lineage_db": "s3://idseq-database/taxonomy/2020-02-10/taxid-lineages.db", "accession2taxid_db": "s3://idseq-database/alignment_data/2020-02-10/accession2taxid.db", "taxon_blacklist": "s3://idseq-database/taxonomy/2018-04-01-utc-1522569777-unixtime__2018-04-04-utc-1522862260-unixtime/taxon_blacklist.txt"}' \
-    --additional-attributes '{"alignment_algorithm": "gsnap", "index_dir_suffix": "2020-02-10"}'
+    --additional-files '{"lineage_db": "~{lineage_db}", "accession2taxid_db": "~{accession2taxid_db}", "taxon_blacklist": "~{taxon_blacklist}"}' \
+    --additional-attributes '{"alignment_algorithm": "gsnap", "index_dir_suffix": "~{index_dir_suffix}"}'
   >>>
   output {
     File gsnap_m8 = "gsnap.m8"
@@ -51,6 +55,10 @@ task RunAlignmentRemotely_rapsearch2_out {
     File host_filter_out_gsnap_filter_2_fa
     File host_filter_out_gsnap_filter_merged_fa
     File cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
+    String lineage_db
+    String accession2taxid_db
+    String taxon_blacklist
+    String index_dir_suffix
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
@@ -65,8 +73,8 @@ task RunAlignmentRemotely_rapsearch2_out {
     --input-files '[["~{host_filter_out_gsnap_filter_1_fa}", "~{host_filter_out_gsnap_filter_2_fa}", "~{host_filter_out_gsnap_filter_merged_fa}"], ["~{cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv}"]]' \
     --output-files '["rapsearch2.m8", "rapsearch2.deduped.m8", "rapsearch2.hitsummary.tab", "rapsearch2_counts_with_dcr.json"]' \
     --output-dir-s3 '~{s3_wd_uri}' \
-    --additional-files '{"lineage_db": "s3://idseq-database/taxonomy/2020-02-10/taxid-lineages.db", "accession2taxid_db": "s3://idseq-database/alignment_data/2020-02-10/accession2taxid.db", "taxon_blacklist": "s3://idseq-database/taxonomy/2018-04-01-utc-1522569777-unixtime__2018-04-04-utc-1522862260-unixtime/taxon_blacklist.txt"}' \
-    --additional-attributes '{"alignment_algorithm": "rapsearch2", "index_dir_suffix": "2020-02-10"}'
+    --additional-files '{"lineage_db": "~{lineage_db}", "accession2taxid_db": "~{accession2taxid_db}", "taxon_blacklist": "~{taxon_blacklist}"}' \
+    --additional-attributes '{"alignment_algorithm": "rapsearch2", "index_dir_suffix": "~{index_dir_suffix}"}'
   >>>
   output {
     File rapsearch2_m8 = "rapsearch2.m8"
@@ -182,6 +190,10 @@ workflow idseq_non_host_alignment {
     File cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
     File cdhitdup_out_dedup1_fa_clstr
     File cdhitdup_out_dedup1_fa
+    String lineage_db
+    String accession2taxid_db
+    String taxon_blacklist
+    String index_dir_suffix
   }
 
   call RunAlignmentRemotely_gsnap_out {
@@ -194,7 +206,11 @@ workflow idseq_non_host_alignment {
       host_filter_out_gsnap_filter_1_fa = host_filter_out_gsnap_filter_1_fa,
       host_filter_out_gsnap_filter_2_fa = host_filter_out_gsnap_filter_2_fa,
       host_filter_out_gsnap_filter_merged_fa = host_filter_out_gsnap_filter_merged_fa,
-      cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv = cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
+      cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv = cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv,
+      lineage_db = lineage_db,
+      accession2taxid_db = accession2taxid_db,
+      taxon_blacklist = taxon_blacklist,
+      index_dir_suffix = index_dir_suffix
   }
 
   call RunAlignmentRemotely_rapsearch2_out {
@@ -207,7 +223,11 @@ workflow idseq_non_host_alignment {
       host_filter_out_gsnap_filter_1_fa = host_filter_out_gsnap_filter_1_fa,
       host_filter_out_gsnap_filter_2_fa = host_filter_out_gsnap_filter_2_fa,
       host_filter_out_gsnap_filter_merged_fa = host_filter_out_gsnap_filter_merged_fa,
-      cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv = cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
+      cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv = cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv,
+      lineage_db = lineage_db,
+      accession2taxid_db = accession2taxid_db,
+      taxon_blacklist = taxon_blacklist,
+      index_dir_suffix = index_dir_suffix
   }
 
   call CombineTaxonCounts {

--- a/main/postprocess.wdl
+++ b/main/postprocess.wdl
@@ -175,6 +175,8 @@ task BlastContigs_refined_gsnap_out {
     File cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
     String lineage_db
     String taxon_blacklist
+    String? deuterostome_db
+    Boolean use_taxon_whitelist
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
@@ -189,8 +191,8 @@ task BlastContigs_refined_gsnap_out {
     --input-files '[["~{gsnap_out_gsnap_m8}", "~{gsnap_out_gsnap_deduped_m8}", "~{gsnap_out_gsnap_hitsummary_tab}", "~{gsnap_out_gsnap_counts_with_dcr_json}"], ["~{assembly_contigs_fasta}", "~{assembly_scaffolds_fasta}", "~{assembly_read_contig_sam}", "~{assembly_contig_stats_json}"], ["~{assembly_nt_refseq_fasta}"], ["~{cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv}"]]' \
     --output-files '["assembly/gsnap.blast.m8", "assembly/gsnap.reassigned.m8", "assembly/gsnap.hitsummary2.tab", "assembly/refined_gsnap_counts_with_dcr.json", "assembly/gsnap_contig_summary.json", "assembly/gsnap.blast.top.m8"]' \
     --output-dir-s3 '~{s3_wd_uri}' \
-    --additional-files '{"lineage_db": "~{lineage_db}", "taxon_blacklist": "~{taxon_blacklist}"}' \
-    --additional-attributes '{"db_type": "nt"}'
+    --additional-files '{"lineage_db": "~{lineage_db}", "taxon_blacklist": "~{taxon_blacklist}", "deuterostome_db": "~{deuterostome_db}"}' \
+    --additional-attributes '{"db_type": "nt", "use_taxon_whitelist": "~{use_taxon_whitelist}"}'
   >>>
   output {
     File assembly_gsnap_blast_m8 = "assembly/gsnap.blast.m8"
@@ -225,6 +227,7 @@ task BlastContigs_refined_rapsearch2_out {
     File cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
     String lineage_db
     String taxon_blacklist
+    Boolean use_taxon_whitelist
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
@@ -240,7 +243,7 @@ task BlastContigs_refined_rapsearch2_out {
     --output-files '["assembly/rapsearch2.blast.m8", "assembly/rapsearch2.reassigned.m8", "assembly/rapsearch2.hitsummary2.tab", "assembly/refined_rapsearch2_counts_with_dcr.json", "assembly/rapsearch2_contig_summary.json", "assembly/rapsearch2.blast.top.m8"]' \
     --output-dir-s3 '~{s3_wd_uri}' \
     --additional-files '{"lineage_db": "~{lineage_db}", "taxon_blacklist": "~{taxon_blacklist}"}' \
-    --additional-attributes '{"db_type": "nr"}'
+    --additional-attributes '{"db_type": "nr", "use_taxon_whitelist": "~{use_taxon_whitelist}"}'
   >>>
   output {
     File assembly_rapsearch2_blast_m8 = "assembly/rapsearch2.blast.m8"
@@ -517,6 +520,8 @@ workflow idseq_postprocess {
     String nr_loc_db
     String lineage_db
     String taxon_blacklist
+    String? deuterostome_db
+    Boolean use_taxon_whitelist
   }
 
   call RunAssembly {
@@ -593,7 +598,9 @@ workflow idseq_postprocess {
       assembly_nt_refseq_fasta = DownloadAccessions_gsnap_accessions_out.assembly_nt_refseq_fasta,
       cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv = cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv,
       lineage_db = lineage_db,
-      taxon_blacklist = taxon_blacklist
+      taxon_blacklist = taxon_blacklist,
+      deuterostome_db = deuterostome_db,
+      use_taxon_whitelist = use_taxon_whitelist
   }
 
   call BlastContigs_refined_rapsearch2_out {
@@ -614,7 +621,8 @@ workflow idseq_postprocess {
       assembly_nr_refseq_fasta = DownloadAccessions_rapsearch2_accessions_out.assembly_nr_refseq_fasta,
       cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv = cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv,
       lineage_db = lineage_db,
-      taxon_blacklist = taxon_blacklist
+      taxon_blacklist = taxon_blacklist,
+      use_taxon_whitelist = use_taxon_whitelist
   }
 
   call CombineTaxonCounts {

--- a/main/postprocess.wdl
+++ b/main/postprocess.wdl
@@ -89,6 +89,9 @@ task DownloadAccessions_gsnap_accessions_out {
     File gsnap_out_gsnap_deduped_m8
     File gsnap_out_gsnap_hitsummary_tab
     File gsnap_out_gsnap_counts_with_dcr_json
+    String nt_db
+    String nt_loc_db
+    String lineage_db
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
@@ -103,8 +106,8 @@ task DownloadAccessions_gsnap_accessions_out {
     --input-files '[["~{gsnap_out_gsnap_m8}", "~{gsnap_out_gsnap_deduped_m8}", "~{gsnap_out_gsnap_hitsummary_tab}", "~{gsnap_out_gsnap_counts_with_dcr_json}"]]' \
     --output-files '["assembly/nt.refseq.fasta"]' \
     --output-dir-s3 '~{s3_wd_uri}' \
-    --additional-files '{"lineage_db": "s3://idseq-database/taxonomy/2020-02-10/taxid-lineages.db", "loc_db": "s3://idseq-database/alignment_data/2020-02-10/nt_loc.db", "db": "s3://idseq-database/alignment_data/2020-02-10/nt"}' \
-    --additional-attributes '{"db": "s3://idseq-database/alignment_data/2020-02-10/nt", "db_type": "nt"}'
+    --additional-files '{"lineage_db": "~{lineage_db}", "loc_db": "~{nt_loc_db}", "db": "~{nt_db}"}' \
+    --additional-attributes '{"db": "~{nt_db}", "db_type": "nt"}'
   >>>
   output {
     File assembly_nt_refseq_fasta = "assembly/nt.refseq.fasta"
@@ -126,6 +129,9 @@ task DownloadAccessions_rapsearch2_accessions_out {
     File rapsearch2_out_rapsearch2_deduped_m8
     File rapsearch2_out_rapsearch2_hitsummary_tab
     File rapsearch2_out_rapsearch2_counts_with_dcr_json
+    String lineage_db
+    String nr_loc_db
+    String nr_db
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
@@ -140,8 +146,8 @@ task DownloadAccessions_rapsearch2_accessions_out {
     --input-files '[["~{rapsearch2_out_rapsearch2_m8}", "~{rapsearch2_out_rapsearch2_deduped_m8}", "~{rapsearch2_out_rapsearch2_hitsummary_tab}", "~{rapsearch2_out_rapsearch2_counts_with_dcr_json}"]]' \
     --output-files '["assembly/nr.refseq.fasta"]' \
     --output-dir-s3 '~{s3_wd_uri}' \
-    --additional-files '{"lineage_db": "s3://idseq-database/taxonomy/2020-02-10/taxid-lineages.db", "loc_db": "s3://idseq-database/alignment_data/2020-02-10/nr_loc.db", "db": "s3://idseq-database/alignment_data/2020-02-10/nr"}' \
-    --additional-attributes '{"db": "s3://idseq-database/alignment_data/2020-02-10/nr", "db_type": "nr"}'
+    --additional-files '{"lineage_db": "~{lineage_db}", "loc_db": "~{nr_loc_db}", "db": "~{nr_db}"}' \
+    --additional-attributes '{"db": "~{nr_db}", "db_type": "nr"}'
   >>>
   output {
     File assembly_nr_refseq_fasta = "assembly/nr.refseq.fasta"
@@ -169,6 +175,8 @@ task BlastContigs_refined_gsnap_out {
     File assembly_contig_stats_json
     File assembly_nt_refseq_fasta
     File cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
+    String lineage_db
+    String taxon_blacklist
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
@@ -183,7 +191,7 @@ task BlastContigs_refined_gsnap_out {
     --input-files '[["~{gsnap_out_gsnap_m8}", "~{gsnap_out_gsnap_deduped_m8}", "~{gsnap_out_gsnap_hitsummary_tab}", "~{gsnap_out_gsnap_counts_with_dcr_json}"], ["~{assembly_contigs_fasta}", "~{assembly_scaffolds_fasta}", "~{assembly_read_contig_sam}", "~{assembly_contig_stats_json}"], ["~{assembly_nt_refseq_fasta}"], ["~{cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv}"]]' \
     --output-files '["assembly/gsnap.blast.m8", "assembly/gsnap.reassigned.m8", "assembly/gsnap.hitsummary2.tab", "assembly/refined_gsnap_counts_with_dcr.json", "assembly/gsnap_contig_summary.json", "assembly/gsnap.blast.top.m8"]' \
     --output-dir-s3 '~{s3_wd_uri}' \
-    --additional-files '{"lineage_db": "s3://idseq-database/taxonomy/2020-02-10/taxid-lineages.db", "taxon_blacklist": "s3://idseq-database/taxonomy/2018-04-01-utc-1522569777-unixtime__2018-04-04-utc-1522862260-unixtime/taxon_blacklist.txt"}' \
+    --additional-files '{"lineage_db": "~{lineage_db}", "taxon_blacklist": "~{taxon_blacklist}"}' \
     --additional-attributes '{"db_type": "nt"}'
   >>>
   output {
@@ -217,6 +225,8 @@ task BlastContigs_refined_rapsearch2_out {
     File assembly_contig_stats_json
     File assembly_nr_refseq_fasta
     File cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
+    String lineage_db
+    String taxon_blacklist
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
@@ -231,7 +241,7 @@ task BlastContigs_refined_rapsearch2_out {
     --input-files '[["~{rapsearch2_out_rapsearch2_m8}", "~{rapsearch2_out_rapsearch2_deduped_m8}", "~{rapsearch2_out_rapsearch2_hitsummary_tab}", "~{rapsearch2_out_rapsearch2_counts_with_dcr_json}"], ["~{assembly_contigs_fasta}", "~{assembly_scaffolds_fasta}", "~{assembly_read_contig_sam}", "~{assembly_contig_stats_json}"], ["~{assembly_nr_refseq_fasta}"], ["~{cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv}"]]' \
     --output-files '["assembly/rapsearch2.blast.m8", "assembly/rapsearch2.reassigned.m8", "assembly/rapsearch2.hitsummary2.tab", "assembly/refined_rapsearch2_counts_with_dcr.json", "assembly/rapsearch2_contig_summary.json", "assembly/rapsearch2.blast.top.m8"]' \
     --output-dir-s3 '~{s3_wd_uri}' \
-    --additional-files '{"lineage_db": "s3://idseq-database/taxonomy/2020-02-10/taxid-lineages.db", "taxon_blacklist": "s3://idseq-database/taxonomy/2018-04-01-utc-1522569777-unixtime__2018-04-04-utc-1522862260-unixtime/taxon_blacklist.txt"}' \
+    --additional-files '{"lineage_db": "~{lineage_db}", "taxon_blacklist": "~{taxon_blacklist}"}' \
     --additional-attributes '{"db_type": "nr"}'
   >>>
   output {
@@ -411,6 +421,7 @@ task GenerateTaxidFasta {
     File assembly_refined_rapsearch2_counts_with_dcr_json
     File assembly_rapsearch2_contig_summary_json
     File assembly_rapsearch2_blast_top_m8
+    String lineage_db
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
@@ -425,7 +436,7 @@ task GenerateTaxidFasta {
     --input-files '[["~{assembly_refined_annotated_merged_fa}", "~{assembly_refined_unidentified_fa}"], ["~{assembly_gsnap_blast_m8}", "~{assembly_gsnap_reassigned_m8}", "~{assembly_gsnap_hitsummary2_tab}", "~{assembly_refined_gsnap_counts_with_dcr_json}", "~{assembly_gsnap_contig_summary_json}", "~{assembly_gsnap_blast_top_m8}"], ["~{assembly_rapsearch2_blast_m8}", "~{assembly_rapsearch2_reassigned_m8}", "~{assembly_rapsearch2_hitsummary2_tab}", "~{assembly_refined_rapsearch2_counts_with_dcr_json}", "~{assembly_rapsearch2_contig_summary_json}", "~{assembly_rapsearch2_blast_top_m8}"]]' \
     --output-files '["assembly/refined_taxid_annot.fasta"]' \
     --output-dir-s3 '~{s3_wd_uri}' \
-    --additional-files '{"lineage_db": "s3://idseq-database/taxonomy/2020-02-10/taxid-lineages.db"}' \
+    --additional-files '{"lineage_db": "~{lineage_db}"}' \
     --additional-attributes '{}'
   >>>
   output {
@@ -504,6 +515,12 @@ workflow idseq_postprocess {
     File cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
     File cdhitdup_out_dedup1_fa_clstr
     File cdhitdup_out_dedup1_fa
+    String nt_db
+    String nt_loc_db
+    String nr_db
+    String nr_loc_db
+    String lineage_db
+    String taxon_blacklist
   }
 
   call RunAssembly {
@@ -542,7 +559,10 @@ workflow idseq_postprocess {
       gsnap_out_gsnap_m8 = gsnap_out_gsnap_m8,
       gsnap_out_gsnap_deduped_m8 = gsnap_out_gsnap_deduped_m8,
       gsnap_out_gsnap_hitsummary_tab = gsnap_out_gsnap_hitsummary_tab,
-      gsnap_out_gsnap_counts_with_dcr_json = gsnap_out_gsnap_counts_with_dcr_json
+      gsnap_out_gsnap_counts_with_dcr_json = gsnap_out_gsnap_counts_with_dcr_json,
+      nt_db = nt_db,
+      nt_loc_db = nt_loc_db,
+      lineage_db = lineage_db
   }
 
   call DownloadAccessions_rapsearch2_accessions_out {
@@ -555,7 +575,10 @@ workflow idseq_postprocess {
       rapsearch2_out_rapsearch2_m8 = rapsearch2_out_rapsearch2_m8,
       rapsearch2_out_rapsearch2_deduped_m8 = rapsearch2_out_rapsearch2_deduped_m8,
       rapsearch2_out_rapsearch2_hitsummary_tab = rapsearch2_out_rapsearch2_hitsummary_tab,
-      rapsearch2_out_rapsearch2_counts_with_dcr_json = rapsearch2_out_rapsearch2_counts_with_dcr_json
+      rapsearch2_out_rapsearch2_counts_with_dcr_json = rapsearch2_out_rapsearch2_counts_with_dcr_json,
+      nr_db = nr_db,
+      nr_loc_db = nr_loc_db,
+      lineage_db = lineage_db
   }
 
   call BlastContigs_refined_gsnap_out {
@@ -574,7 +597,9 @@ workflow idseq_postprocess {
       assembly_read_contig_sam = RunAssembly.assembly_read_contig_sam,
       assembly_contig_stats_json = RunAssembly.assembly_contig_stats_json,
       assembly_nt_refseq_fasta = DownloadAccessions_gsnap_accessions_out.assembly_nt_refseq_fasta,
-      cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv = cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
+      cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv = cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv,
+      lineage_db = lineage_db,
+      taxon_blacklist = taxon_blacklist
   }
 
   call BlastContigs_refined_rapsearch2_out {
@@ -593,7 +618,9 @@ workflow idseq_postprocess {
       assembly_read_contig_sam = RunAssembly.assembly_read_contig_sam,
       assembly_contig_stats_json = RunAssembly.assembly_contig_stats_json,
       assembly_nr_refseq_fasta = DownloadAccessions_rapsearch2_accessions_out.assembly_nr_refseq_fasta,
-      cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv = cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
+      cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv = cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv,
+      lineage_db = lineage_db,
+      taxon_blacklist = taxon_blacklist
   }
 
   call CombineTaxonCounts {
@@ -685,7 +712,8 @@ workflow idseq_postprocess {
       assembly_rapsearch2_hitsummary2_tab = BlastContigs_refined_rapsearch2_out.assembly_rapsearch2_hitsummary2_tab,
       assembly_refined_rapsearch2_counts_with_dcr_json = BlastContigs_refined_rapsearch2_out.assembly_refined_rapsearch2_counts_with_dcr_json,
       assembly_rapsearch2_contig_summary_json = BlastContigs_refined_rapsearch2_out.assembly_rapsearch2_contig_summary_json,
-      assembly_rapsearch2_blast_top_m8 = BlastContigs_refined_rapsearch2_out.assembly_rapsearch2_blast_top_m8
+      assembly_rapsearch2_blast_top_m8 = BlastContigs_refined_rapsearch2_out.assembly_rapsearch2_blast_top_m8,
+      lineage_db = lineage_db
   }
 
   call GenerateTaxidLocator {

--- a/main/postprocess.wdl
+++ b/main/postprocess.wdl
@@ -7,14 +7,12 @@ task RunAssembly {
     String deployment_env
     String dag_branch
     String s3_wd_uri
-    File host_filter_out_gsnap_filter_1_fa
-    File host_filter_out_gsnap_filter_2_fa
-    File host_filter_out_gsnap_filter_merged_fa
+    Array[File] host_filter_out_gsnap_filter_fa
     File cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -22,7 +20,7 @@ task RunAssembly {
     --step-module idseq_dag.steps.run_assembly \
     --step-class PipelineStepRunAssembly \
     --step-name assembly_out \
-    --input-files '[["~{host_filter_out_gsnap_filter_1_fa}", "~{host_filter_out_gsnap_filter_2_fa}", "~{host_filter_out_gsnap_filter_merged_fa}"], ["~{cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv}"]]' \
+    --input-files '[["~{sep='","' host_filter_out_gsnap_filter_fa}"], ["~{cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv}"]]' \
     --output-files '["assembly/contigs.fasta", "assembly/scaffolds.fasta", "assembly/read-contig.sam", "assembly/contig_stats.json"]' \
     --output-dir-s3 '~{s3_wd_uri}' \
     --additional-files '{}' \
@@ -54,7 +52,7 @@ task GenerateCoverageStats {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -95,7 +93,7 @@ task DownloadAccessions_gsnap_accessions_out {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -135,7 +133,7 @@ task DownloadAccessions_rapsearch2_accessions_out {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -180,7 +178,7 @@ task BlastContigs_refined_gsnap_out {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -230,7 +228,7 @@ task BlastContigs_refined_rapsearch2_out {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -280,7 +278,7 @@ task CombineTaxonCounts {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -325,7 +323,7 @@ task CombineJson {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -355,9 +353,7 @@ task GenerateAnnotatedFasta {
     String deployment_env
     String dag_branch
     String s3_wd_uri
-    File host_filter_out_gsnap_filter_1_fa
-    File host_filter_out_gsnap_filter_2_fa
-    File host_filter_out_gsnap_filter_merged_fa
+    Array[File] host_filter_out_gsnap_filter_fa
     File assembly_gsnap_blast_m8
     File assembly_gsnap_reassigned_m8
     File assembly_gsnap_hitsummary2_tab
@@ -376,7 +372,7 @@ task GenerateAnnotatedFasta {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -384,7 +380,7 @@ task GenerateAnnotatedFasta {
     --step-module idseq_dag.steps.generate_annotated_fasta \
     --step-class PipelineStepGenerateAnnotatedFasta \
     --step-name refined_annotated_out \
-    --input-files '[["~{host_filter_out_gsnap_filter_1_fa}", "~{host_filter_out_gsnap_filter_2_fa}", "~{host_filter_out_gsnap_filter_merged_fa}"], ["~{assembly_gsnap_blast_m8}", "~{assembly_gsnap_reassigned_m8}", "~{assembly_gsnap_hitsummary2_tab}", "~{assembly_refined_gsnap_counts_with_dcr_json}", "~{assembly_gsnap_contig_summary_json}", "~{assembly_gsnap_blast_top_m8}"], ["~{assembly_rapsearch2_blast_m8}", "~{assembly_rapsearch2_reassigned_m8}", "~{assembly_rapsearch2_hitsummary2_tab}", "~{assembly_refined_rapsearch2_counts_with_dcr_json}", "~{assembly_rapsearch2_contig_summary_json}", "~{assembly_rapsearch2_blast_top_m8}"], ["~{cdhitdup_out_dedup1_fa_clstr}", "~{cdhitdup_out_dedup1_fa}"], ["~{cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv}"]]' \
+    --input-files '[["~{sep='","' host_filter_out_gsnap_filter_fa}"], ["~{assembly_gsnap_blast_m8}", "~{assembly_gsnap_reassigned_m8}", "~{assembly_gsnap_hitsummary2_tab}", "~{assembly_refined_gsnap_counts_with_dcr_json}", "~{assembly_gsnap_contig_summary_json}", "~{assembly_gsnap_blast_top_m8}"], ["~{assembly_rapsearch2_blast_m8}", "~{assembly_rapsearch2_reassigned_m8}", "~{assembly_rapsearch2_hitsummary2_tab}", "~{assembly_refined_rapsearch2_counts_with_dcr_json}", "~{assembly_rapsearch2_contig_summary_json}", "~{assembly_rapsearch2_blast_top_m8}"], ["~{cdhitdup_out_dedup1_fa_clstr}", "~{cdhitdup_out_dedup1_fa}"], ["~{cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv}"]]' \
     --output-files '["assembly/refined_annotated_merged.fa", "assembly/refined_unidentified.fa"]' \
     --output-dir-s3 '~{s3_wd_uri}' \
     --additional-files '{}' \
@@ -425,7 +421,7 @@ task GenerateTaxidFasta {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -459,7 +455,7 @@ task GenerateTaxidLocator {
   }
   command<<<
   export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
-  if ! [[ -z "~{dag_branch}" ]]; then
+  if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
   set -x
@@ -502,8 +498,8 @@ workflow idseq_postprocess {
     String dag_branch
     String s3_wd_uri
     File host_filter_out_gsnap_filter_1_fa
-    File host_filter_out_gsnap_filter_2_fa
-    File host_filter_out_gsnap_filter_merged_fa
+    File? host_filter_out_gsnap_filter_2_fa
+    File? host_filter_out_gsnap_filter_merged_fa
     File gsnap_out_gsnap_m8
     File gsnap_out_gsnap_deduped_m8
     File gsnap_out_gsnap_hitsummary_tab
@@ -530,9 +526,7 @@ workflow idseq_postprocess {
       deployment_env = deployment_env,
       dag_branch = dag_branch,
       s3_wd_uri = s3_wd_uri,
-      host_filter_out_gsnap_filter_1_fa = host_filter_out_gsnap_filter_1_fa,
-      host_filter_out_gsnap_filter_2_fa = host_filter_out_gsnap_filter_2_fa,
-      host_filter_out_gsnap_filter_merged_fa = host_filter_out_gsnap_filter_merged_fa,
+      host_filter_out_gsnap_filter_fa = select_all([host_filter_out_gsnap_filter_1_fa, host_filter_out_gsnap_filter_2_fa, host_filter_out_gsnap_filter_merged_fa]),
       cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv = cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
   }
 
@@ -672,9 +666,7 @@ workflow idseq_postprocess {
       deployment_env = deployment_env,
       dag_branch = dag_branch,
       s3_wd_uri = s3_wd_uri,
-      host_filter_out_gsnap_filter_1_fa = host_filter_out_gsnap_filter_1_fa,
-      host_filter_out_gsnap_filter_2_fa = host_filter_out_gsnap_filter_2_fa,
-      host_filter_out_gsnap_filter_merged_fa = host_filter_out_gsnap_filter_merged_fa,
+      host_filter_out_gsnap_filter_fa = select_all([host_filter_out_gsnap_filter_1_fa, host_filter_out_gsnap_filter_2_fa, host_filter_out_gsnap_filter_merged_fa]),
       assembly_gsnap_blast_m8 = BlastContigs_refined_gsnap_out.assembly_gsnap_blast_m8,
       assembly_gsnap_reassigned_m8 = BlastContigs_refined_gsnap_out.assembly_gsnap_reassigned_m8,
       assembly_gsnap_hitsummary2_tab = BlastContigs_refined_gsnap_out.assembly_gsnap_hitsummary2_tab,

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+
+for tag in $(git tag); do
+    for file in $(git ls-tree -r --name-only "$tag" | grep '.wdl$'); do
+        git show "${tag}:${file}" | aws s3 cp - "s3://idseq-workflows/${tag}/${file}"
+    done
+done

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 for tag in $(git tag); do
     for file in $(git ls-tree -r --name-only "$tag" | grep '.wdl$'); do
+        echo "Uploading: $tag $file"
         git show "${tag}:${file}" | aws s3 cp - "s3://idseq-workflows/${tag}/${file}"
     done
 done

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -5,6 +5,6 @@ set -euo pipefail
 for tag in $(git tag); do
     for file in $(git ls-tree -r --name-only "$tag" | grep '.wdl$'); do
         echo "Uploading: $tag $file"
-        git show "${tag}:${file}" | aws s3 cp - "s3://idseq-workflows/${tag}/${file}"
+        git show "${tag}:${file}" | aws s3 cp --acl public-read - "s3://idseq-workflows/${tag}/${file}"
     done
 done


### PR DESCRIPTION
- Parameterize workflow inputs that were passed as "attributes" in idseq-dag and rendered as literals by idd2wdl
- Manually re-introduce conditional logic to handle single vs paired-end fastqs
- Manually re-introduce conditional logic to handle human host filtering when indicated host is not human
- Add a publish script that writes all workflow WDLs for every tag in the repo to s3://idseq-workflows