### PR TITLE
start phasing out aws_region and deployment_env inputs

### DIFF
--- a/main/experimental.wdl
+++ b/main/experimental.wdl
@@ -3,8 +3,8 @@ version 1.0
 task GenerateTaxidFasta {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     File taxid_fasta_in_annotated_merged_fa
@@ -12,7 +12,8 @@ task GenerateTaxidFasta {
     File taxid_fasta_in_rapsearch2_hitsummary_tab
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -39,14 +40,15 @@ task GenerateTaxidFasta {
 task GenerateTaxidLocator {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     File taxid_annot_fasta
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -85,8 +87,8 @@ task GenerateTaxidLocator {
 task GenerateAlignmentViz {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     File gsnap_m8_gsnap_deduped_m8
@@ -107,7 +109,8 @@ task GenerateAlignmentViz {
     String nt_loc_db
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -135,15 +138,16 @@ task GenerateAlignmentViz {
 task RunSRST2 {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     Array[File] fastqs
     String file_ext
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -175,8 +179,8 @@ task RunSRST2 {
 task GenerateCoverageViz {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     File refined_gsnap_in_gsnap_reassigned_m8
@@ -189,7 +193,8 @@ task GenerateCoverageViz {
     String nt_info_db
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -217,8 +222,8 @@ task GenerateCoverageViz {
 task NonhostFastq {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     Array[File] fastqs
@@ -228,7 +233,8 @@ task NonhostFastq {
     Boolean use_taxon_whitelist
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -256,8 +262,8 @@ task NonhostFastq {
 workflow idseq_experimental {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     File taxid_fasta_in_annotated_merged_fa

--- a/main/host_filter.wdl
+++ b/main/host_filter.wdl
@@ -3,8 +3,8 @@ version 1.0
 task RunValidateInput {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     Array[File] fastqs
@@ -12,8 +12,9 @@ task RunValidateInput {
     String file_ext
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
   set -euxo pipefail
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
   fi
@@ -42,8 +43,8 @@ task RunValidateInput {
 task RunStar {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     File validate_input_summary_json
@@ -53,7 +54,8 @@ task RunStar {
     String host_genome
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -84,15 +86,16 @@ task RunStar {
 task RunTrimmomatic {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     Array[File] unmapped_fastq
     String adapter_fasta
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -120,14 +123,15 @@ task RunTrimmomatic {
 task RunPriceSeq {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     Array[File] trimmomatic_fastq
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -155,14 +159,15 @@ task RunPriceSeq {
 task RunCDHitDup {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     Array[File] priceseq_fa
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -192,8 +197,8 @@ task RunCDHitDup {
 task RunLZW {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     Array[File] dedup_fa
@@ -201,7 +206,8 @@ task RunLZW {
     File cdhitdup_cluster_sizes_tsv
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -229,8 +235,8 @@ task RunLZW {
 task RunBowtie2_bowtie2_out {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     Array[File] lzw_fa
@@ -240,7 +246,8 @@ task RunBowtie2_bowtie2_out {
     String bowtie2_genome
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -269,8 +276,8 @@ task RunBowtie2_bowtie2_out {
 task RunSubsample {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     Array[File] bowtie2_fa
@@ -280,7 +287,8 @@ task RunSubsample {
     Int max_subsample_fragments
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -309,8 +317,8 @@ task RunSubsample {
 task RunStarDownstream {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     Array[File] subsampled_fa
@@ -322,7 +330,8 @@ task RunStarDownstream {
     String human_star_genome
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -350,8 +359,8 @@ task RunStarDownstream {
 task RunBowtie2_bowtie2_human_out {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     Array[File] unmapped_human_fa
@@ -361,7 +370,8 @@ task RunBowtie2_bowtie2_human_out {
     String human_bowtie2_genome
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -390,8 +400,8 @@ task RunBowtie2_bowtie2_human_out {
 task RunGsnapFilter {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     Array[File] subsampled_fa
@@ -400,7 +410,8 @@ task RunGsnapFilter {
     File cdhitdup_cluster_sizes_tsv
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -429,8 +440,8 @@ task RunGsnapFilter {
 workflow idseq_host_filter {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     File fastqs_0

--- a/main/non_host_alignment.wdl
+++ b/main/non_host_alignment.wdl
@@ -3,8 +3,8 @@ version 1.0
 task RunAlignmentRemotely_gsnap_out {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     Array[File] host_filter_out_gsnap_filter_fa
@@ -17,7 +17,8 @@ task RunAlignmentRemotely_gsnap_out {
     Boolean use_taxon_whitelist
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -47,8 +48,8 @@ task RunAlignmentRemotely_gsnap_out {
 task RunAlignmentRemotely_rapsearch2_out {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     Array[File] host_filter_out_gsnap_filter_fa
@@ -60,7 +61,8 @@ task RunAlignmentRemotely_rapsearch2_out {
     Boolean use_taxon_whitelist
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -90,8 +92,8 @@ task RunAlignmentRemotely_rapsearch2_out {
 task CombineTaxonCounts {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     File gsnap_m8
@@ -104,7 +106,8 @@ task CombineTaxonCounts {
     File rapsearch2_counts_with_dcr_json
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -131,8 +134,8 @@ task CombineTaxonCounts {
 task GenerateAnnotatedFasta {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     Array[File] host_filter_out_gsnap_filter_fa
@@ -149,7 +152,8 @@ task GenerateAnnotatedFasta {
     File cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -177,8 +181,8 @@ task GenerateAnnotatedFasta {
 workflow idseq_non_host_alignment {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     File host_filter_out_gsnap_filter_1_fa

--- a/main/postprocess.wdl
+++ b/main/postprocess.wdl
@@ -3,15 +3,16 @@ version 1.0
 task RunAssembly {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     Array[File] host_filter_out_gsnap_filter_fa
     File cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -41,8 +42,8 @@ task RunAssembly {
 task GenerateCoverageStats {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     File assembly_contigs_fasta
@@ -51,7 +52,8 @@ task GenerateCoverageStats {
     File assembly_contig_stats_json
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -79,8 +81,8 @@ task GenerateCoverageStats {
 task DownloadAccessions_gsnap_accessions_out {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     File gsnap_out_gsnap_m8
@@ -92,7 +94,8 @@ task DownloadAccessions_gsnap_accessions_out {
     String lineage_db
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -119,8 +122,8 @@ task DownloadAccessions_gsnap_accessions_out {
 task DownloadAccessions_rapsearch2_accessions_out {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     File rapsearch2_out_rapsearch2_m8
@@ -132,7 +135,8 @@ task DownloadAccessions_rapsearch2_accessions_out {
     String nr_db
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -159,8 +163,8 @@ task DownloadAccessions_rapsearch2_accessions_out {
 task BlastContigs_refined_gsnap_out {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     File gsnap_out_gsnap_m8
@@ -179,7 +183,8 @@ task BlastContigs_refined_gsnap_out {
     Boolean use_taxon_whitelist
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -211,8 +216,8 @@ task BlastContigs_refined_gsnap_out {
 task BlastContigs_refined_rapsearch2_out {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     File rapsearch2_out_rapsearch2_m8
@@ -230,7 +235,8 @@ task BlastContigs_refined_rapsearch2_out {
     Boolean use_taxon_whitelist
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -262,8 +268,8 @@ task BlastContigs_refined_rapsearch2_out {
 task CombineTaxonCounts {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     File assembly_gsnap_blast_m8
@@ -280,7 +286,8 @@ task CombineTaxonCounts {
     File assembly_rapsearch2_blast_top_m8
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -307,8 +314,8 @@ task CombineTaxonCounts {
 task CombineJson {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     File assembly_gsnap_blast_m8
@@ -325,7 +332,8 @@ task CombineJson {
     File assembly_rapsearch2_blast_top_m8
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -352,8 +360,8 @@ task CombineJson {
 task GenerateAnnotatedFasta {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     Array[File] host_filter_out_gsnap_filter_fa
@@ -374,7 +382,8 @@ task GenerateAnnotatedFasta {
     File cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -402,8 +411,8 @@ task GenerateAnnotatedFasta {
 task GenerateTaxidFasta {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     File assembly_refined_annotated_merged_fa
@@ -423,7 +432,8 @@ task GenerateTaxidFasta {
     String lineage_db
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -450,14 +460,15 @@ task GenerateTaxidFasta {
 task GenerateTaxidLocator {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     File assembly_refined_taxid_annot_fasta
   }
   command<<<
-  export AWS_DEFAULT_REGION=~{aws_region} DEPLOYMENT_ENVIRONMENT=~{deployment_env}
+  ~{"export AWS_DEFAULT_REGION=" + aws_region}
+  ~{"export DEPLOYMENT_ENVIRONMENT=" + deployment_env}
   set -euxo pipefail
   if [[ -n "~{dag_branch}" ]]; then
     pip3 install --upgrade https://github.com/chanzuckerberg/idseq-dag/archive/~{dag_branch}.tar.gz
@@ -496,8 +507,8 @@ task GenerateTaxidLocator {
 workflow idseq_postprocess {
   input {
     String docker_image_id
-    String aws_region
-    String deployment_env
+    String? aws_region
+    String? deployment_env
     String dag_branch
     String s3_wd_uri
     File host_filter_out_gsnap_filter_1_fa


### PR DESCRIPTION
@kislyuk proposing this way to phase out the aws_region and deployment_env inputs, which 'should' already be unnecessary, but something could still go wrong of course. Making them optional, so we can take them out of the inputs and later when we're satisfied they're no longer needed, delete them entirely.

The interpolation uses a [WDL trick](https://github.com/openwdl/wdl/blob/master/versions/development/SPEC.md#interpolating-and-concatenating-optional-strings) which evaluates `~{"foo" + x}` to the empty string if x is null. 