### PR TITLE
enable more task tests by letting miniwdl handle small/medium S3 downloads

### DIFF
--- a/.github/workflows/wdl-ci.yml
+++ b/.github/workflows/wdl-ci.yml
@@ -73,6 +73,6 @@ jobs:
 
           export DOCKER_IMAGE_ID="${IMAGE_URI}:${TAG}"
           # wip:
-          export IDSEQ_DAG_BRANCH=mlin-auto-local-untar
+          export IDSEQ_DAG_BRANCH=master
 
           make test-${{ matrix.workflow_dir }}

--- a/.github/workflows/wdl-ci.yml
+++ b/.github/workflows/wdl-ci.yml
@@ -72,7 +72,5 @@ jobs:
           pip install -r requirements-dev.txt
 
           export DOCKER_IMAGE_ID="${IMAGE_URI}:${TAG}"
-          # wip:
-          export IDSEQ_DAG_BRANCH=master
 
           make test-${{ matrix.workflow_dir }}

--- a/.github/workflows/wdl-ci.yml
+++ b/.github/workflows/wdl-ci.yml
@@ -59,14 +59,20 @@ jobs:
           echo "::set-env name=TAG::${TAG}"
       - name: run tests
         run: |
+          # explicitly block EC2 IMDS endpoint to work around awscli issue:
+          # https://github.com/aws/aws-cli/issues/5234#issuecomment-635459464
+          # https://github.com/aws/aws-cli/issues/5262
+          sudo ip route add blackhole 169.254.169.254
+
           source /etc/profile
           sudo apt-get -qq update
           sudo apt-get -qq install --yes jq moreutils make virtualenv zip unzip httpie git shellcheck
           virtualenv --python=python3.6 .venv
           source .venv/bin/activate
           pip install -r requirements-dev.txt
+
           export DOCKER_IMAGE_ID="${IMAGE_URI}:${TAG}"
-          # https://github.com/aws/aws-cli/issues/5234#issuecomment-635459464
-          # https://github.com/aws/aws-cli/issues/5262
-          sudo ip route add blackhole 169.254.169.254
+          # wip:
+          export IDSEQ_DAG_BRANCH=mlin-auto-local-untar
+
           make test-${{ matrix.workflow_dir }}

--- a/.github/workflows/wdl-ci.yml
+++ b/.github/workflows/wdl-ci.yml
@@ -66,4 +66,7 @@ jobs:
           source .venv/bin/activate
           pip install -r requirements-dev.txt
           export DOCKER_IMAGE_ID="${IMAGE_URI}:${TAG}"
+          # https://github.com/aws/aws-cli/issues/5234#issuecomment-635459464
+          # https://github.com/aws/aws-cli/issues/5262
+          ip route add blackhole 169.254.169.254
           make test-${{ matrix.workflow_dir }}

--- a/.github/workflows/wdl-ci.yml
+++ b/.github/workflows/wdl-ci.yml
@@ -68,5 +68,5 @@ jobs:
           export DOCKER_IMAGE_ID="${IMAGE_URI}:${TAG}"
           # https://github.com/aws/aws-cli/issues/5234#issuecomment-635459464
           # https://github.com/aws/aws-cli/issues/5262
-          ip route add blackhole 169.254.169.254
+          sudo ip route add blackhole 169.254.169.254
           make test-${{ matrix.workflow_dir }}

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ publish:
 	scripts/publish.sh
 
 test-%:
-	pytest -v -n 4 --tb=short --log-cli-level=11 tests/$*
+	pytest -v -n `python3 -c 'import multiprocessing as mp; print(max(1,mp.cpu_count()-1))'` --tb=short --log-cli-level=11 tests/$*
 
 test: test-main
 

--- a/main/experimental.wdl
+++ b/main/experimental.wdl
@@ -8,6 +8,7 @@ task GenerateTaxidFasta {
     File taxid_fasta_in_annotated_merged_fa
     File taxid_fasta_in_gsnap_hitsummary_tab
     File taxid_fasta_in_rapsearch2_hitsummary_tab
+    File lineage_db
   }
   command<<<
   set -euxo pipefail
@@ -21,7 +22,7 @@ task GenerateTaxidFasta {
     --input-files '[["~{taxid_fasta_in_annotated_merged_fa}", "~{taxid_fasta_in_gsnap_hitsummary_tab}", "~{taxid_fasta_in_rapsearch2_hitsummary_tab}"]]' \
     --output-files '["taxid_annot.fasta"]' \
     --output-dir-s3 '~{s3_wd_uri}' \
-    --additional-files '{"lineage_db": "s3://idseq-database/taxonomy/2020-02-10/taxid-lineages.db"}' \
+    --additional-files '{"lineage_db": "~{lineage_db}"}' \
     --additional-attributes '{}'
   >>>
   output {
@@ -261,6 +262,7 @@ workflow idseq_experimental {
     String nt_db = "s3://~{idseq_db_bucket}/ncbi-sources/~{index_version}/nt"
     String nt_loc_db = "s3://~{idseq_db_bucket}/alignment_data/~{index_version}/nt_loc.db"
     String nt_info_db = "s3://~{idseq_db_bucket}/alignment_data/~{index_version}/nt_info.db"
+    File lineage_db = "s3://idseq-database/taxonomy/2020-02-10/taxid-lineages.db"
     Boolean use_taxon_whitelist = false
   }
 
@@ -271,7 +273,8 @@ workflow idseq_experimental {
       s3_wd_uri = s3_wd_uri,
       taxid_fasta_in_annotated_merged_fa = taxid_fasta_in_annotated_merged_fa,
       taxid_fasta_in_gsnap_hitsummary_tab = taxid_fasta_in_gsnap_hitsummary_tab,
-      taxid_fasta_in_rapsearch2_hitsummary_tab = taxid_fasta_in_rapsearch2_hitsummary_tab
+      taxid_fasta_in_rapsearch2_hitsummary_tab = taxid_fasta_in_rapsearch2_hitsummary_tab,
+      lineage_db = lineage_db
   }
 
   call GenerateTaxidLocator {

--- a/main/host_filter.wdl
+++ b/main/host_filter.wdl
@@ -43,7 +43,7 @@ task RunStar {
     String s3_wd_uri
     File validate_input_summary_json
     Array[File] valid_input_fastq
-    String star_genome
+    File star_genome
     String nucleotide_type
     String host_genome
   }
@@ -217,7 +217,7 @@ task RunBowtie2_bowtie2_out {
     Array[File] dedup_fa
     File dedup1_fa_clstr
     File cdhitdup_cluster_sizes_tsv
-    String bowtie2_genome
+    File bowtie2_genome
   }
   command<<<
   set -euxo pipefail
@@ -293,7 +293,7 @@ task RunStarDownstream {
     Array[File] dedup_fa
     File dedup1_fa_clstr
     File cdhitdup_cluster_sizes_tsv
-    String human_star_genome
+    File human_star_genome
   }
   command<<<
   set -euxo pipefail
@@ -329,7 +329,7 @@ task RunBowtie2_bowtie2_human_out {
     Array[File] dedup_fa
     File dedup1_fa_clstr
     File cdhitdup_cluster_sizes_tsv
-    String human_bowtie2_genome
+    File human_bowtie2_genome
   }
   command<<<
   set -euxo pipefail
@@ -366,6 +366,7 @@ task RunGsnapFilter {
     Array[File] dedup_fa
     File dedup1_fa_clstr
     File cdhitdup_cluster_sizes_tsv
+    File gsnap_genome = "s3://idseq-database/host_filter/human/2018-02-15-utc-1518652800-unixtime__2018-02-15-utc-1518652800-unixtime/hg38_pantro5_k16.tar"
   }
   command<<<
   set -euxo pipefail
@@ -379,7 +380,7 @@ task RunGsnapFilter {
     --input-files '[["~{sep='","' subsampled_fa}"], ["~{sep='","' dedup_fa}", "~{dedup1_fa_clstr}", "~{cdhitdup_cluster_sizes_tsv}"]]' \
     --output-files '[~{if length(dedup_fa) == 2 then '"gsnap_filter_1.fa", "gsnap_filter_2.fa", "gsnap_filter_merged.fa"' else '"gsnap_filter_1.fa"'}]' \
     --output-dir-s3 '~{s3_wd_uri}' \
-    --additional-files '{"gsnap_genome": "s3://idseq-database/host_filter/human/2018-02-15-utc-1518652800-unixtime__2018-02-15-utc-1518652800-unixtime/hg38_pantro5_k16.tar"}' \
+    --additional-files '{"gsnap_genome": "~{gsnap_genome}"}' \
     --additional-attributes '{"output_sam_file": "gsnap_filter.sam"}'
   >>>
   output {

--- a/main/host_filter.wdl
+++ b/main/host_filter.wdl
@@ -366,7 +366,7 @@ task RunGsnapFilter {
     Array[File] dedup_fa
     File dedup1_fa_clstr
     File cdhitdup_cluster_sizes_tsv
-    File gsnap_genome = "s3://idseq-database/host_filter/human/2018-02-15-utc-1518652800-unixtime__2018-02-15-utc-1518652800-unixtime/hg38_pantro5_k16.tar"
+    File gsnap_genome
   }
   command<<<
   set -euxo pipefail
@@ -405,8 +405,9 @@ workflow idseq_host_filter {
     String nucleotide_type
     String host_genome
     File adapter_fasta
-    String star_genome
-    String bowtie2_genome
+    File star_genome
+    File bowtie2_genome
+    File gsnap_genome = "s3://idseq-database/host_filter/human/2018-02-15-utc-1518652800-unixtime__2018-02-15-utc-1518652800-unixtime/hg38_pantro5_k16.tar"
     String human_star_genome
     String human_bowtie2_genome
     Int max_input_fragments
@@ -534,7 +535,8 @@ workflow idseq_host_filter {
       subsampled_fa = gsnap_filter_input,
       dedup_fa = select_all([RunCDHitDup.dedup1_fa, RunCDHitDup.dedup2_fa]),
       dedup1_fa_clstr = RunCDHitDup.dedup1_fa_clstr,
-      cdhitdup_cluster_sizes_tsv = RunCDHitDup.cdhitdup_cluster_sizes_tsv
+      cdhitdup_cluster_sizes_tsv = RunCDHitDup.cdhitdup_cluster_sizes_tsv,
+      gsnap_genome = gsnap_genome
   }
 
   output {

--- a/main/postprocess.wdl
+++ b/main/postprocess.wdl
@@ -160,7 +160,7 @@ task BlastContigs_refined_gsnap_out {
     File assembly_nt_refseq_fasta
     File cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
     File lineage_db
-    String taxon_blacklist
+    File taxon_blacklist
     String? deuterostome_db
     Boolean use_deuterostome_filter
     Boolean use_taxon_whitelist
@@ -210,7 +210,7 @@ task BlastContigs_refined_rapsearch2_out {
     File assembly_nr_refseq_fasta
     File cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
     File lineage_db
-    String taxon_blacklist
+    File taxon_blacklist
     Boolean use_taxon_whitelist
   }
   command<<<
@@ -487,7 +487,7 @@ workflow idseq_postprocess {
     String nr_db = "s3://~{idseq_db_bucket}/ncbi-sources/~{index_version}/nr"
     String nr_loc_db = "s3://~{idseq_db_bucket}/alignment_data/~{index_version}/nr_loc.db"
     File lineage_db = "s3://~{idseq_db_bucket}/taxonomy/~{index_version}/taxid-lineages.db"
-    String taxon_blacklist = "s3://~{idseq_db_bucket}/taxonomy/~{index_version}/taxon_blacklist.txt"
+    File taxon_blacklist = "s3://~{idseq_db_bucket}/taxonomy/~{index_version}/taxon_blacklist.txt"
     String deuterostome_db = "s3://~{idseq_db_bucket}/taxonomy/~{index_version}/deuterostome_taxids.txt"
     Boolean use_deuterostome_filter = true
     Boolean use_taxon_whitelist = false

--- a/main/postprocess.wdl
+++ b/main/postprocess.wdl
@@ -81,7 +81,7 @@ task DownloadAccessions_gsnap_accessions_out {
     File gsnap_out_gsnap_counts_with_dcr_json
     String nt_db
     String nt_loc_db
-    String lineage_db
+    File lineage_db
   }
   command<<<
   set -euxo pipefail
@@ -116,7 +116,7 @@ task DownloadAccessions_rapsearch2_accessions_out {
     File rapsearch2_out_rapsearch2_deduped_m8
     File rapsearch2_out_rapsearch2_hitsummary_tab
     File rapsearch2_out_rapsearch2_counts_with_dcr_json
-    String lineage_db
+    File lineage_db
     String nr_loc_db
     String nr_db
   }
@@ -159,7 +159,7 @@ task BlastContigs_refined_gsnap_out {
     File assembly_contig_stats_json
     File assembly_nt_refseq_fasta
     File cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
-    String lineage_db
+    File lineage_db
     String taxon_blacklist
     String? deuterostome_db
     Boolean use_deuterostome_filter
@@ -209,7 +209,7 @@ task BlastContigs_refined_rapsearch2_out {
     File assembly_contig_stats_json
     File assembly_nr_refseq_fasta
     File cdhitdup_cluster_sizes_cdhitdup_cluster_sizes_tsv
-    String lineage_db
+    File lineage_db
     String taxon_blacklist
     Boolean use_taxon_whitelist
   }

--- a/main/postprocess.wdl
+++ b/main/postprocess.wdl
@@ -392,7 +392,7 @@ task GenerateTaxidFasta {
     File assembly_refined_rapsearch2_counts_with_dcr_json
     File assembly_rapsearch2_contig_summary_json
     File assembly_rapsearch2_blast_top_m8
-    String lineage_db
+    File lineage_db
   }
   command<<<
   set -euxo pipefail
@@ -486,7 +486,7 @@ workflow idseq_postprocess {
     String nt_loc_db = "s3://~{idseq_db_bucket}/alignment_data/~{index_version}/nt_loc.db"
     String nr_db = "s3://~{idseq_db_bucket}/ncbi-sources/~{index_version}/nr"
     String nr_loc_db = "s3://~{idseq_db_bucket}/alignment_data/~{index_version}/nr_loc.db"
-    String lineage_db = "s3://~{idseq_db_bucket}/taxonomy/~{index_version}/taxid-lineages.db"
+    File lineage_db = "s3://~{idseq_db_bucket}/taxonomy/~{index_version}/taxid-lineages.db"
     String taxon_blacklist = "s3://~{idseq_db_bucket}/taxonomy/~{index_version}/taxon_blacklist.txt"
     String deuterostome_db = "s3://~{idseq_db_bucket}/taxonomy/~{index_version}/deuterostome_taxids.txt"
     Boolean use_deuterostome_filter = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-miniwdl
+miniwdl>=0.8.0
 pre-commit
 pytest
 pytest-xdist

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ INPUT_OVERRIDES = {
         "DOCKER_IMAGE_ID",
         "docker.pkg.github.com/chanzuckerberg/idseq-workflows/idseq-main-public:6fc07e6",
     ),
-    "dag_branch": "",
+    "dag_branch": os.environ.get("IDSEQ_DAG_BRANCH", ""),
     "s3_wd_uri": "s3://DUMMY_URI/",
 }
 

--- a/tests/main/experimental/tasks/GenerateTaxidFasta/bench3/inputs.json
+++ b/tests/main/experimental/tasks/GenerateTaxidFasta/bench3/inputs.json
@@ -4,5 +4,6 @@
   "s3_wd_uri": "s3://DUMMY_BKT/",
   "taxid_fasta_in_annotated_merged_fa": "input_files/refined_annotated_merged.fa",
   "taxid_fasta_in_gsnap_hitsummary_tab": "input_files/gsnap.hitsummary.tab",
-  "taxid_fasta_in_rapsearch2_hitsummary_tab": "input_files/rapsearch2.hitsummary.tab"
+  "taxid_fasta_in_rapsearch2_hitsummary_tab": "input_files/rapsearch2.hitsummary.tab",
+  "lineage_db": "s3://idseq-database/taxonomy/2020-02-10/taxid-lineages.db"
 }

--- a/tests/main/experimental/tasks/GenerateTaxidFasta/bench3/test_experimental_bench3_GenerateTaxidFasta.py
+++ b/tests/main/experimental/tasks/GenerateTaxidFasta/bench3/test_experimental_bench3_GenerateTaxidFasta.py
@@ -10,7 +10,6 @@ def inputs_outputs(exe, load_inputs_outputs):
     return load_inputs_outputs(exe, os.path.dirname(__file__))
 
 
-@pytest.mark.skip(reason="needs File s3:// download")
 def test_bench3_GenerateTaxidFasta(exe, inputs_outputs, miniwdl_run, compare_outputs):
     # Load the test inputs & expected outputs
     (inputs, expected_outputs) = inputs_outputs

--- a/tests/main/host_filter/tasks/RunBowtie2_bowtie2_out/bench3/test_bench3_RunBowtie2_bowtie2_out.py
+++ b/tests/main/host_filter/tasks/RunBowtie2_bowtie2_out/bench3/test_bench3_RunBowtie2_bowtie2_out.py
@@ -9,7 +9,6 @@ def inputs_outputs(exe, load_inputs_outputs):
     return load_inputs_outputs(exe, os.path.dirname(__file__))
 
 
-@pytest.mark.xfail
 def test_bench3_RunBowtie2_bowtie2_out(exe, inputs_outputs, miniwdl_run, compare_outputs):
     # Load the test inputs & expected outputs
     (inputs, expected_outputs) = inputs_outputs

--- a/tests/main/host_filter/tasks/RunGsnapFilter/bench3/inputs.json
+++ b/tests/main/host_filter/tasks/RunGsnapFilter/bench3/inputs.json
@@ -12,5 +12,6 @@
     "input_files/dedup2.fa"
   ],
   "dedup1_fa_clstr": "input_files/dedup1.fa.clstr",
-  "cdhitdup_cluster_sizes_tsv": "input_files/cdhitdup_cluster_sizes.tsv"
+  "cdhitdup_cluster_sizes_tsv": "input_files/cdhitdup_cluster_sizes.tsv",
+  "gsnap_genome": "s3://idseq-database/host_filter/human/2018-02-15-utc-1518652800-unixtime__2018-02-15-utc-1518652800-unixtime/hg38_pantro5_k16.tar"
 }

--- a/tests/main/host_filter/tasks/RunGsnapFilter/bench3/test_bench3_RunGsnapFilter.py
+++ b/tests/main/host_filter/tasks/RunGsnapFilter/bench3/test_bench3_RunGsnapFilter.py
@@ -9,7 +9,6 @@ def inputs_outputs(exe, load_inputs_outputs):
     return load_inputs_outputs(exe, os.path.dirname(__file__))
 
 
-@pytest.mark.xfail
 def test_bench3_RunGsnapFilter(exe, inputs_outputs, miniwdl_run, compare_outputs):
     # Load the test inputs & expected outputs
     (inputs, expected_outputs) = inputs_outputs

--- a/tests/main/host_filter/tasks/RunGsnapFilter/bench3/test_bench3_RunGsnapFilter.py
+++ b/tests/main/host_filter/tasks/RunGsnapFilter/bench3/test_bench3_RunGsnapFilter.py
@@ -9,6 +9,7 @@ def inputs_outputs(exe, load_inputs_outputs):
     return load_inputs_outputs(exe, os.path.dirname(__file__))
 
 
+@pytest.mark.skip(reason="16GB reference database")
 def test_bench3_RunGsnapFilter(exe, inputs_outputs, miniwdl_run, compare_outputs):
     # Load the test inputs & expected outputs
     (inputs, expected_outputs) = inputs_outputs

--- a/tests/main/host_filter/tasks/RunStar/bench3/test_bench3_RunStar.py
+++ b/tests/main/host_filter/tasks/RunStar/bench3/test_bench3_RunStar.py
@@ -9,7 +9,6 @@ def inputs_outputs(exe, load_inputs_outputs):
     return load_inputs_outputs(exe, os.path.dirname(__file__))
 
 
-@pytest.mark.xfail
 def test_bench3_RunStar(exe, inputs_outputs, miniwdl_run, compare_outputs):
     # Load the test inputs & expected outputs
     (inputs, expected_outputs) = inputs_outputs

--- a/tests/main/host_filter/tasks/RunStar/bench3/test_bench3_RunStar.py
+++ b/tests/main/host_filter/tasks/RunStar/bench3/test_bench3_RunStar.py
@@ -9,6 +9,7 @@ def inputs_outputs(exe, load_inputs_outputs):
     return load_inputs_outputs(exe, os.path.dirname(__file__))
 
 
+@pytest.mark.skip(reason="27GB reference database")
 def test_bench3_RunStar(exe, inputs_outputs, miniwdl_run, compare_outputs):
     # Load the test inputs & expected outputs
     (inputs, expected_outputs) = inputs_outputs

--- a/tests/main/postprocess/tasks/BlastContigs_refined_rapsearch2_out/bench3/test_bench3_BlastContigs_refined_rapsearch2_out.py
+++ b/tests/main/postprocess/tasks/BlastContigs_refined_rapsearch2_out/bench3/test_bench3_BlastContigs_refined_rapsearch2_out.py
@@ -10,7 +10,6 @@ def inputs_outputs(exe, load_inputs_outputs):
     return load_inputs_outputs(exe, os.path.dirname(__file__))
 
 
-@pytest.mark.skip(reason="needs S3 download + LZ4 auto-decompression")
 def test_bench3_BlastContigs_refined_rapsearch2_out(exe, inputs_outputs, miniwdl_run, compare_outputs):
     # Load the test inputs & expected outputs
     (inputs, expected_outputs) = inputs_outputs

--- a/tests/main/postprocess/tasks/GenerateTaxidFasta/bench3/test_postprocess_bench3_GenerateTaxidFasta.py
+++ b/tests/main/postprocess/tasks/GenerateTaxidFasta/bench3/test_postprocess_bench3_GenerateTaxidFasta.py
@@ -10,7 +10,6 @@ def inputs_outputs(exe, load_inputs_outputs):
     return load_inputs_outputs(exe, os.path.dirname(__file__))
 
 
-@pytest.mark.skip(reason="needs File s3:// download")
 def test_bench3_GenerateTaxidFasta(exe, inputs_outputs, miniwdl_run, compare_outputs):
     # Load the test inputs & expected outputs
     (inputs, expected_outputs) = inputs_outputs


### PR DESCRIPTION
The skeleton test cases for these three steps had been marked xfail while we work through public access to their reference databases on S3. Now miniwdl v0.8.0 can download public s3:// URIs without any external plugin.

* For small/medium downloads, changes the URI `String` inputs to `File` so that miniwdl takes over downloading
* the star and gsnap cases work, but the databases are too large to use in Actions or arguably for "unit tests" in general (27GB and 16GB). have marked them 'skip'
* because the auto-untar for star and gsnap host filter databases are no longer streaming, this diff would cause (moderate) speed and disk space usage regressions in production
* also skipped are tasks using nr/nt databases which are larger; leaving these handled by idseq-dag for the moment.
* eventually we may either store the databases under a S3 key prefix without tarring, or allow miniwdl's future implementation of the WDL 2.0 Directory type to accept tar inputs (which would be a useful but nonstandard feature)

