### PR TITLE
switch to a warning for multiple emitted reads from the same cluster

### DIFF
--- a/short-read-mngs/idseq-dag/README.md
+++ b/short-read-mngs/idseq-dag/README.md
@@ -226,6 +226,9 @@ Changes to X or Y force recomputation of all results when a sample is rerun usin
 
 When releasing a new version, please add a Git tag of the form `vX.Y.Z`.
 
+- 4.11.9
+  - Switch from assertion that cd-hit-clusters only emit one read to a warning if they emit more than one read
+
 - 4.11.8
   - Support local non-host alignment
 

--- a/short-read-mngs/idseq-dag/idseq_dag/__init__.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/__init__.py
@@ -1,2 +1,2 @@
 ''' idseq_dag '''
-__version__ = "4.11.8"
+__version__ = "4.11.9"


### PR DESCRIPTION
Switch this assertion with a warning so it doesn't crash the whole pipeline.