### PR TITLE
Catch shell pipeline failures in run_srst2

### DIFF
--- a/short-read-mngs/idseq-dag/idseq_dag/steps/run_srst2.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/steps/run_srst2.py
@@ -138,6 +138,7 @@ class PipelineStepRunSRST2(PipelineStep):
         command.execute(
             command_patterns.ShellScriptCommand(
                 script='''
+                    set -o pipefail;
                     bedtools bamtobed -i "$1" |
                     env LC_ALL=C sort -T "$2" -k1,1 -k2,2n |
                     bedtools coverage -sorted -a "$3" -b stdin > "$4";''',


### PR DESCRIPTION
See prod pipeline run 77427 for an example of why this is needed.