### PR TITLE
Remove dag_branch from consensus-genome

### DIFF
--- a/consensus-genome/run.wdl
+++ b/consensus-genome/run.wdl
@@ -39,7 +39,6 @@ workflow consensus_genome {
 
         # Dummy values - required by SFN interface
         String s3_wd_uri
-        String dag_branch
     }
 
     call RemoveHost {

--- a/consensus-genome/run.wdl
+++ b/consensus-genome/run.wdl
@@ -1,5 +1,5 @@
 # The following pipeline was initially based on previous work at: https://github.com/czbiohub/sc2-illumina-pipeline
-# workflow version: consensus-genomes-1.2.4
+# workflow version: consensus-genomes-1.2.5
 version 1.0
 
 workflow consensus_genome {


### PR DESCRIPTION
I think this is needed after the change in https://github.com/chanzuckerberg/idseq/pull/246