### PR TITLE
local alignment: extract db to temp space instead of output dir

### DIFF
--- a/short-read-mngs/idseq-dag/idseq_dag/steps/run_alignment.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/steps/run_alignment.py
@@ -8,6 +8,7 @@ import time
 import traceback
 import json
 import re
+import tempfile
 from subprocess import run, PIPE
 from urllib.parse import urlparse
 from botocore.exceptions import ClientError
@@ -191,38 +192,39 @@ class PipelineStepRunAlignment(PipelineStep):
             output_counts_with_dcr_json)
 
     def run_locally(self, input_fas, output_m8):
-        index_path = os.path.join(os.path.dirname(output_m8), "reference")
-        os.mkdir(index_path)
-        run(["tar", "-xzvf", self.index, "-C", index_path], check=True)
+        with tempfile.TemporaryDirectory(prefix=self.alignment_algorithm) as tmpdir:
+            index_path = os.path.join(tmpdir, "reference")
+            os.mkdir(index_path)
+            run(["tar", "-xzvf", self.index, "-C", index_path], check=True)
 
-        if self.alignment_algorithm == "gsnap":
-            # Hack to determine gsnap vs gsnapl
-            error_message = run(
-                ['gsnapl.avx2-2018-10-26', '-D', index_path, '-d', self.genome_name],
-                input='>'.encode('utf-8'),
-                stderr=PIPE,
-                stdout=PIPE
-            ).stderr
-            # note, alignment uses a pinned version of gmap/gsnap
-            gsnap_command = "gsnap.avx2-2018-10-26" if 'please run gsnap instead' in error_message.decode('utf-8') else "gsnapl.avx2-2018-10-26"
-        else:
-            gsnap_command = None
+            if self.alignment_algorithm == "gsnap":
+                # Hack to determine gsnap vs gsnapl
+                error_message = run(
+                    ['gsnapl.avx2-2018-10-26', '-D', index_path, '-d', self.genome_name],
+                    input='>'.encode('utf-8'),
+                    stderr=PIPE,
+                    stdout=PIPE
+                ).stderr
+                # note, alignment uses a pinned version of gmap/gsnap
+                gsnap_command = "gsnap.avx2-2018-10-26" if 'please run gsnap instead' in error_message.decode('utf-8') else "gsnapl.avx2-2018-10-26"
+            else:
+                gsnap_command = None
 
-        # rapsearch2 expects the filename of the primary file, but still depends on the .info file being a sibbling
-        if self.alignment_algorithm == "rapsearch2":
-            for filename in os.listdir(index_path):
-                if not filename.endswith(".info"):
-                    index_path = os.path.join(index_path, filename)
+            # rapsearch2 expects the filename of the primary file, but still depends on the .info file being a sibbling
+            if self.alignment_algorithm == "rapsearch2":
+                for filename in os.listdir(index_path):
+                    if not filename.endswith(".info"):
+                        index_path = os.path.join(index_path, filename)
 
-        cmd = self._get_command(
-            index_path,
-            input_fas,
-            output_m8,
-            threads=multiprocessing.cpu_count(),
-            gsnap_command=gsnap_command
-        )
-        log.write(f"running command {cmd}")
-        run(cmd, check=True)
+            cmd = self._get_command(
+                index_path,
+                input_fas,
+                output_m8,
+                threads=multiprocessing.cpu_count(),
+                gsnap_command=gsnap_command
+            )
+            log.write(f"running command {cmd}")
+            run(cmd, check=True)
 
     def run_remotely(self, input_fas, output_m8):
         # Split files into chunks for performance


### PR DESCRIPTION
Improves efficiency when miniwdl is using a shared filesystem for working directories, per https://miniwdl.readthedocs.io/en/latest/runner_advanced.html#write-scratch-files-under-tmpdir