### PR TITLE
Fix file reference to use miniwdl download caching logic

### DIFF
--- a/short-read-mngs/postprocess.wdl
+++ b/short-read-mngs/postprocess.wdl
@@ -144,7 +144,7 @@ task BlastContigs_refined_gsnap_out {
     File duplicate_cluster_sizes_tsv
     File lineage_db
     File taxon_blacklist
-    String? deuterostome_db
+    File deuterostome_db
     Boolean use_deuterostome_filter
     Boolean use_taxon_whitelist
   }


### PR DESCRIPTION
### Description

For the `short-read-mngs` pipeline, found just one misconfiguration leading to a download from `idseq-dag` code.

Note that are a few events of `fetch_from_s3` in the logs. Those seem to come all from the phylo tree pipeline.

### Test

Tested by doing a local run. All files were download by miniwdl.