### PR TITLE
Fail if kSNP3 produces empty output

### DIFF
--- a/short-read-mngs/idseq-dag/idseq_dag/steps/generate_phylo_tree.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/steps/generate_phylo_tree.py
@@ -146,9 +146,17 @@ class PipelineStepGeneratePhyloTree(PipelineStep):
                 args=ksnap_args
             )
         )
+        tree_output = os.path.join(ksnp_output_dir, "tree.parsimony.tre")
+
+        # kSNP3 sometimes outputs an empty file when it fails instead of
+        #   returning a non-zero code. This effectively causes the
+        #   step to silently fail which causes problems downstream
+        #   If this happens we should fail here, and not upload
+        #   the output
+        assert os.path.getsize(tree_output) > 0, "kSNP3 encountered an issue and produced a tree file of size 0"
 
         # Postprocess output names in preparation for upload:
-        command.move_file(os.path.join(ksnp_output_dir, "tree.parsimony.tre"), output_files[0])
+        command.move_file(tree_output, output_files[0])
         ksnp_vcf_file = glob.glob(f"{ksnp_output_dir}/*.vcf")
         if ksnp_vcf_file:
             target_vcf_file = f"{ksnp_output_dir}/variants_reference1.vcf"


### PR DESCRIPTION
This fixes a downstream issue where some failed phylo trees appear to be pending forever. This happened because the job completed successfully but produced an empty output tree file. This empy file allowed the job to appear complete from the perspective of idseq-dag's engine and therefore batch. However, when the results monitor checks for this result it downloads it and an empy file appears missing in that case. This empty output is produced by kSNP3 for certain failure modes it seems, instead of exiting with a non-zero code which would raise an exception and cause the job to fail.

I breifly considered checking for an empty file in the web app but I think that would be a mistake. This empty file is produced in the case of a failure. The job should not succeed if it fails. I think it is reasonable for the web app to assume that if output was produced it is valid. 

I did some repro steps on prod (not changing anything just observing behavior of some of the functions) and I am quite confident this will fix the issue.

Fun coincience, just yesterday I added the ability to make code changes to the phylo tree code again. Perfect timing 😎 However, this change can't go live until we do a deploy of the web application.