### PR TITLE
[CH-27791] Add check for "No reads after MakeConsensus"

### DIFF
--- a/consensus-genome/run.wdl
+++ b/consensus-genome/run.wdl
@@ -445,6 +445,12 @@ task MakeConsensus {
         samtools mpileup -A -d 0 -Q0 "~{bam}" | ivar consensus -q "~{ivarQualThreshold}" -t "~{ivarFreqThreshold}" -m "~{minDepth}" -n N -p "~{prefix}primertrimmed.consensus"
         echo ">""~{sample}" > "~{prefix}consensus.fa"
         seqtk seq -l 50 "~{prefix}primertrimmed.consensus.fa" | tail -n +2 >> "~{prefix}consensus.fa"
+
+        if [[ $(wc -l "~{prefix}consensus.fa" | cut -d' ' -f1) == 1 ]]; then
+            set +x
+            >&2 echo "{\"wdl_error_message\": true, \"error\": \"InsufficientReadsError\", \"cause\": \"No reads after MakeConsensus\"}"
+            exit 1
+        fi
     >>>
 
     output {

--- a/consensus-genome/run.wdl
+++ b/consensus-genome/run.wdl
@@ -1,5 +1,5 @@
 # The following pipeline was initially based on previous work at: https://github.com/czbiohub/sc2-illumina-pipeline
-# workflow version: consensus-genomes-1.4.1
+# workflow version: consensus-genomes-1.5.1
 version 1.0
 
 workflow consensus_genome {

--- a/consensus-genome/run.wdl
+++ b/consensus-genome/run.wdl
@@ -446,6 +446,7 @@ task MakeConsensus {
         echo ">""~{sample}" > "~{prefix}consensus.fa"
         seqtk seq -l 50 "~{prefix}primertrimmed.consensus.fa" | tail -n +2 >> "~{prefix}consensus.fa"
 
+        # One-line file means just the fasta header with no reads
         if [[ $(wc -l "~{prefix}consensus.fa" | cut -d' ' -f1) == 1 ]]; then
             set +x
             >&2 echo "{\"wdl_error_message\": true, \"error\": \"InsufficientReadsError\", \"cause\": \"No reads after MakeConsensus\"}"

--- a/consensus-genome/run.wdl
+++ b/consensus-genome/run.wdl
@@ -1,5 +1,5 @@
 # The following pipeline was initially based on previous work at: https://github.com/czbiohub/sc2-illumina-pipeline
-# workflow version: consensus-genomes-1.5.1
+# workflow version: consensus-genomes-1.4.2
 version 1.0
 
 workflow consensus_genome {


### PR DESCRIPTION
- Tickets: https://app.clubhouse.io/idseq/story/27791/bug-on-computestats-step-of-consensus-genome-pipeline

# Description
- This should address the issues noted in the bug. We just need to check if the `consensus.fa` file has any actual reads.

# Tests
- Tested directly on an EC2-IA instance in production. I tested 3 of the samples noted in the ticket and successfully got the error message.

![Screen Shot 2020-12-17 at 6 36 34 PM](https://user-images.githubusercontent.com/5652739/102568209-df911a00-4097-11eb-90eb-80c17b231782.png)

- As a sanity check, I also ran a "normal sample" and it was successful.