### PR TITLE
enable the ability to create generic consensus genomes

### DIFF
--- a/consensus-genome/README.md
+++ b/consensus-genome/README.md
@@ -21,7 +21,7 @@ miniwdl run --verbose consensus-genome/run.wdl \
 
 Where:
 
-* `docker_image_id=` should be set to the docker image tag you used when building the image (in our example, `idseq-consensus-genone`)
+* `docker_image_id=` should be set to the docker image tag you used when building the image (in our example, `idseq-consensus-genome`)
 * `consensus-genome/run.wdl` is the WDL for the consensus genome sequencing workflow.
 * `fastqs_0` and `fastqs_1` are the pair of FASTQ files. The ones referred to are small files to run locally.
 * `sample` is the name to use where referencing the sample in the output files.

--- a/consensus-genome/run.wdl
+++ b/consensus-genome/run.wdl
@@ -1,5 +1,5 @@
 # The following pipeline was initially based on previous work at: https://github.com/czbiohub/sc2-illumina-pipeline
-# workflow version: consensus-genomes-1.5.2
+# workflow version: consensus-genomes-1.5.0
 version 1.0
 
 workflow consensus_genome {
@@ -58,7 +58,7 @@ workflow consensus_genome {
             docker_image_id = docker_image_id
     }
 
-    if (filter_reads){
+    if (filter_reads) {
         call FilterReads {
             input:
                 prefix = prefix,

--- a/consensus-genome/run.wdl
+++ b/consensus-genome/run.wdl
@@ -25,6 +25,7 @@ workflow consensus_genome {
 
         # all of the following seem to be parameters in params.* of the nextflow pipeline;
         # could they be extracted to a separate params file? put in .json input to wdl?
+        Boolean filter_reads = true
         Boolean trim_adapters = true
 
         Float ivarFreqThreshold = 0.9
@@ -57,19 +58,21 @@ workflow consensus_genome {
             docker_image_id = docker_image_id
     }
 
-    call FilterReads {
-        input:
-            prefix = prefix,
-            fastqs = RemoveHost.host_removed_fastqs,
-            ref_fasta = ref_fasta,
-            kraken2_db_tar_gz = kraken2_db_tar_gz,
-            docker_image_id = docker_image_id
+    if (filter_reads){
+        call FilterReads {
+            input:
+                prefix = prefix,
+                fastqs = RemoveHost.host_removed_fastqs,
+                ref_fasta = ref_fasta,
+                kraken2_db_tar_gz = kraken2_db_tar_gz,
+                docker_image_id = docker_image_id
+        }
     }
 
     if (trim_adapters) {
         call TrimReads {
             input:
-                fastqs = FilterReads.filtered_fastqs,
+                fastqs = select_first([FilterReads.filtered_fastqs, RemoveHost.host_removed_fastqs]),
                 docker_image_id = docker_image_id
         }
     }
@@ -78,8 +81,9 @@ workflow consensus_genome {
         input:
             prefix = prefix,
             sample = sample,
-            # use trimReads output if we ran it; otherwise fall back to FilterReads output
-            fastqs = select_first([TrimReads.trimmed_fastqs, FilterReads.filtered_fastqs]),
+            # use trimReads output if we ran it; otherwise fall back to FilterReads output if we ran it; 
+            # otherwise fall back to RemoveHost output
+            fastqs = select_first([TrimReads.trimmed_fastqs, FilterReads.filtered_fastqs, RemoveHost.host_removed_fastqs]),
             ref_fasta = ref_fasta,
             docker_image_id = docker_image_id
     }
@@ -164,7 +168,7 @@ workflow consensus_genome {
     output {
         Array[File] remove_host_out_host_removed_fastqs = RemoveHost.host_removed_fastqs
         File quantify_erccs_out_ercc_out = QuantifyERCCs.ercc_out
-        Array[File]+ filter_reads_out_filtered_fastqs = FilterReads.filtered_fastqs
+        Array[File]+? filter_reads_out_filtered_fastqs = FilterReads.filtered_fastqs
         Array[File]+? trim_reads_out_trimmed_fastqs = TrimReads.trimmed_fastqs
         File? align_reads_out_alignments = AlignReads.alignments
         File? trim_primers_out_trimmed_bam_ch = TrimPrimers.trimmed_bam_ch

--- a/consensus-genome/run.wdl
+++ b/consensus-genome/run.wdl
@@ -1,5 +1,5 @@
 # The following pipeline was initially based on previous work at: https://github.com/czbiohub/sc2-illumina-pipeline
-# workflow version: consensus-genomes-1.4.2
+# workflow version: consensus-genomes-1.5.2
 version 1.0
 
 workflow consensus_genome {


### PR DESCRIPTION
### Description

This PR makes it possible to create a generic consensus genome using the wdl workflow by passing the appropriate inputs (reference genome and primer files) and making the `filterReads` step optional. To generate generic consensus genomes, you would now need to include `"filter_reads": false` in the .json of wdl inputs. 

note: this PR does not add additional error handling logic to ensure that a reference genome is of the correct format (.fasta) or any additional error handling.

### Tests

- Tested locally on several different viruses and verified that the results look appropriate via comparison to ground truth genomes.
- Tested on staging using the `run_sfn.py` script. In particular, I tested that 1. it works with a "generic" non-sars-cov-2 reference genome (tested CHKV genome) and 2. verified that it still generates the same results for two different sars-cov-2 samples - one with PE inputs using ARTIC v3 and one with SE inputs using MSSPE. 
