### PR TITLE
Filter taxids out of hit summaries

### DIFF
--- a/short-read-mngs/idseq-dag/idseq_dag/steps/blast_contigs.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/steps/blast_contigs.py
@@ -383,7 +383,10 @@ class PipelineStepBlastContigs(PipelineStep):  # pylint: disable=abstract-method
 
             for read_id, contig_id in read2contig.items():
                 (accession, m8_row) = contig2accession.get(contig_id, (None, None))
-                if accession:
+                # accession_dict comes from hit_summary, which comes from alignment and is filtered for taxids
+                # this means that we don't need to filter here because we will never get unfiltered taxids from
+                # accession_dict, however it may be missing accessions so we must handle that case.
+                if accession and accession in accession_dict:
                     (species_taxid, genus_taxid, family_taxid) = accession_dict[accession]
                     if read_id in consolidated_dict:
                         consolidated_dict[read_id]["taxid"] = species_taxid

--- a/short-read-mngs/idseq-dag/idseq_dag/util/lineage.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/util/lineage.py
@@ -1,10 +1,10 @@
-from typing import List
+from typing import List, Sequence, Iterator
 
 INVALID_CALL_BASE_ID = -(10**8)
-NULL_SPECIES_ID = -100
-NULL_GENUS_ID = -200
-NULL_FAMILY_ID = -300
-NULL_LINEAGE = (str(NULL_SPECIES_ID), str(NULL_GENUS_ID), str(NULL_FAMILY_ID))
+NULL_SPECIES_ID = "-100"
+NULL_GENUS_ID = "-200"
+NULL_FAMILY_ID = "-300"
+NULL_LINEAGE = (NULL_SPECIES_ID, NULL_GENUS_ID, NULL_FAMILY_ID)
 
 DEFAULT_BLACKLIST_S3 = 's3://idseq-public-references/taxonomy/2018-04-01-utc-1522569777-unixtime__2018-04-04-utc-1522862260-unixtime/taxon_blacklist.txt'
 DEFAULT_WHITELIST_S3 = 's3://idseq-public-references/taxonomy/2020-02-10/respiratory_taxon_whitelist.txt'
@@ -28,22 +28,18 @@ DEFAULT_WHITELIST_S3 = 's3://idseq-public-references/taxonomy/2020-02-10/respira
 # See also comments under call_hits_m8().
 
 
-def cleaned_taxid_lineage(taxid_lineage: str, hit_taxid: int, hit_level: int) -> List[str]:
+def _cleaned_taxid_lineage(taxid_lineage: Sequence[str], hit_taxid: str, hit_level: int) -> Iterator[str]:
     """Take the taxon lineage and mark meaningless calls with fake taxids."""
     # This assumption is being made in postprocessing
     assert len(taxid_lineage) == 3
-    result = [None, None, None]
     for tax_level, taxid in enumerate(taxid_lineage, 1):
         if tax_level >= hit_level:
-            taxid_str = str(taxid)
+            yield taxid
         else:
-            taxid_str = str(
-                tax_level * INVALID_CALL_BASE_ID - hit_taxid)
-        result[tax_level - 1] = taxid_str
-    return result
+            yield tax_level * INVALID_CALL_BASE_ID - int(hit_taxid)
 
 
-def fill_missing_calls(cleaned_lineage: List[str]) -> List[str]:
+def _fill_missing_calls(cleaned_lineage: Sequence[str]) -> List[str]:
     """Replace missing calls with virtual taxids as shown in
     fill_missing_calls_tests. Replaces the negative call IDs with a
     calculated negative value that embeds the next higher positive call in it
@@ -58,33 +54,33 @@ def fill_missing_calls(cleaned_lineage: List[str]) -> List[str]:
     tax_level = len(cleaned_lineage)
     closest_real_hit_just_above_me = -1
 
-    while tax_level > 0:
+    for tax_level in range(len(cleaned_lineage), 0, -1):
         me = int(cleaned_lineage[tax_level - 1])
         if me >= 0:
             closest_real_hit_just_above_me = me
-        elif closest_real_hit_just_above_me >= 0 and blank(me):
+        elif closest_real_hit_just_above_me >= 0 and _blank(me):
             result[tax_level - 1] = str(tax_level * INVALID_CALL_BASE_ID - closest_real_hit_just_above_me)
-        tax_level -= 1
     return result
 
 
-def blank(taxid_int):
+def _blank(taxid_int: int):
     return 0 > taxid_int > INVALID_CALL_BASE_ID
 
 
 def fill_missing_calls_tests():
     # TODO: Move these to a test file later
     # -200 => -200001534
-    assert fill_missing_calls((55, -200, 1534)) == [55, "-200001534", 1534]
+    assert _fill_missing_calls(("55", "-200", "1534")) == ["55", "-200001534", "1534"]
     # -100 => -100005888
-    assert fill_missing_calls((-100, 5888, -300)) == ["-100005888", 5888, -300]
+    assert _fill_missing_calls(("-100", "5888", "-300")) == ["-100005888", "5888", "-300"]
     # -100 => -100001534, -200 => -200001534
-    assert fill_missing_calls((-100, -200,
-                               1534)) == ["-100001534", "-200001534", 1534]
+    assert _fill_missing_calls(("-100", "-200",
+                               "1534")) == ["-100001534", "-200001534", "1534"]
     # no change
-    assert fill_missing_calls((55, -200, -300)) == [55, -200, -300]
+    assert _fill_missing_calls(("55", "-200", "-300")) == ["55", "-200", "-300"]
 
 
-def validate_taxid_lineage(taxid_lineage: str, hit_taxid: int, hit_level: int) -> List[str]:
-    cleaned = cleaned_taxid_lineage(taxid_lineage, hit_taxid, hit_level)
-    return fill_missing_calls(cleaned)
+def validate_taxid_lineage(taxid_lineage: Sequence[str], hit_taxid: str, hit_level: int) -> List[str]:
+    cleaned = _cleaned_taxid_lineage(taxid_lineage, hit_taxid, hit_level)
+    return _fill_missing_calls(list(cleaned))
+

--- a/short-read-mngs/idseq-dag/idseq_dag/util/m8.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/util/m8.py
@@ -446,9 +446,8 @@ def build_should_keep_filter(
     taxon_blacklist_path
 ):
 
-    # TODO: (tmorse)
     # See also HOMO_SAPIENS_TAX_IDS in idseq-web
-    taxids_to_remove = set(['9605', '9606', "37124", "2169701"])
+    taxids_to_remove = set(['9605', '9606'])
 
     if taxon_blacklist_path:
         with log.log_context("generate_taxon_count_json_from_m8", {"substep": "read_blacklist_into_set"}):

--- a/short-read-mngs/idseq-dag/idseq_dag/util/m8.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/util/m8.py
@@ -67,7 +67,8 @@ def read_file_into_set(file_name):
 
 @command.run_in_subprocess
 def call_hits_m8(input_m8, lineage_map_path, accession2taxid_dict_path,
-                 output_m8, output_summary, min_alignment_length):
+                 output_m8, output_summary, min_alignment_length,
+                 deuterostome_path, taxon_whitelist_path, taxon_blacklist_path):
     """
     Determine the optimal taxon assignment for each read from the alignment
     results. When a read aligns to multiple distinct references, we need to
@@ -130,12 +131,17 @@ def call_hits_m8(input_m8, lineage_map_path, accession2taxid_dict_path,
     with open_file_db_by_extension(lineage_map_path) as lineage_map, \
          open_file_db_by_extension(accession2taxid_dict_path) as accession2taxid_dict:  # noqa
         _call_hits_m8_work(input_m8, lineage_map, accession2taxid_dict,
-                           output_m8, output_summary, min_alignment_length)
+                           output_m8, output_summary, min_alignment_length,
+                           deuterostome_path, taxon_whitelist_path, taxon_blacklist_path)
 
 
 def _call_hits_m8_work(input_blastn_6_path, lineage_map, accession2taxid_dict,
-                       output_blastn_6_path, output_summary, min_alignment_length):
+                       output_blastn_6_path, output_summary, min_alignment_length,
+                       deuterostome_path, taxon_whitelist_path, taxon_blacklist_path):
     lineage_cache = {}
+
+    should_keep = build_should_keep_filter(
+        deuterostome_path, taxon_whitelist_path, taxon_blacklist_path)
 
     # Helper functions
     def get_lineage(accession_id):
@@ -258,8 +264,7 @@ def _call_hits_m8_work(input_blastn_6_path, lineage_map, accession2taxid_dict,
             # Read the fields from the summary level info
             best_e_value, _, (hit_level, taxid,
                               best_accession_id) = summary[read_id]
-            if best_e_value == e_value and best_accession_id in (
-                    None, accession_id):
+            if best_e_value == e_value and best_accession_id in (None, accession_id) and should_keep([taxid]):
                 # Read out the hit with the best value that provides the
                 # most specific taxonomy information.
                 emitted.add(read_id)

--- a/short-read-mngs/idseq-dag/idseq_dag/util/m8.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/util/m8.py
@@ -5,7 +5,7 @@ import random
 
 from collections import Counter
 from collections import defaultdict
-from types import Iterable
+from typing import Iterable
 
 import idseq_dag.util.command as command
 import idseq_dag.util.lineage as lineage

--- a/short-read-mngs/idseq-dag/idseq_dag/util/m8.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/util/m8.py
@@ -5,6 +5,7 @@ import random
 
 from collections import Counter
 from collections import defaultdict
+from types import Iterable
 
 import idseq_dag.util.command as command
 import idseq_dag.util.lineage as lineage
@@ -460,13 +461,13 @@ def build_should_keep_filter(
         with log.log_context("generate_taxon_count_json_from_m8", {"substep": "read_whitelist_into_set"}):
             taxids_to_keep = read_file_into_set(taxon_whitelist_path)
 
-    def is_blacklisted(hits):
+    def is_blacklisted(hits: Iterable[str]):
         for taxid in hits:
             if int(taxid) >= 0 and taxid in taxids_to_remove:
                 return True
         return False
 
-    def is_whitelisted(hits):
+    def is_whitelisted(hits: Iterable[str]):
         if not taxon_whitelist_path:
             return True
         for taxid in hits:
@@ -474,7 +475,9 @@ def build_should_keep_filter(
                 return True
         return False
 
-    def should_keep(hits):
+    def should_keep(hits: Iterable[str]):
+        # TODO (tmorse): remove
+        assert all(type(h) == str for h in hits), f"non-string input {hits}"
         return is_whitelisted(hits) and not is_blacklisted(hits)
 
     return should_keep

--- a/short-read-mngs/idseq-dag/idseq_dag/util/m8.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/util/m8.py
@@ -109,7 +109,7 @@ def call_hits_m8(input_m8, lineage_map_path, accession2taxid_dict_path,
         negative ID. The artificial ID is defined based on a negative base (
         INVALID_CALL_BASE_ID), the taxon level (e.g. 2 for genus), and the
         valid parent ID (e.g. genus Escherichia's taxon ID): see helper
-        function cleaned_taxid_lineage for the precise formula.
+        function _cleaned_taxid_lineage for the precise formula.
 
         - Certain entries in NCBI may not have a full lineage classification;
         for example species and family will be defined but genus will be

--- a/short-read-mngs/idseq-dag/idseq_dag/util/m8.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/util/m8.py
@@ -446,8 +446,9 @@ def build_should_keep_filter(
     taxon_blacklist_path
 ):
 
+    # TODO: (tmorse)
     # See also HOMO_SAPIENS_TAX_IDS in idseq-web
-    taxids_to_remove = set(['9605', '9606'])
+    taxids_to_remove = set(['9605', '9606', "37124", "2169701"])
 
     if taxon_blacklist_path:
         with log.log_context("generate_taxon_count_json_from_m8", {"substep": "read_blacklist_into_set"}):

--- a/short-read-mngs/idseq-dag/idseq_dag/util/m8.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/util/m8.py
@@ -483,3 +483,4 @@ def build_should_keep_filter(
         return is_whitelisted(hits) and not is_blacklisted(hits)
 
     return should_keep
+

--- a/short-read-mngs/idseq-dag/idseq_dag/util/m8.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/util/m8.py
@@ -476,8 +476,10 @@ def build_should_keep_filter(
         return False
 
     def should_keep(hits: Iterable[str]):
-        # TODO (tmorse): remove
-        assert all(type(h) == str for h in hits), f"non-string input {hits}"
+        # In some places in the code taxids are ints rather than strings, this would lead
+        # to a silent failure here so it is worth the explicit check.
+        non_strings = [h for h in hits if type(h) != str]
+        assert not non_strings, f"should_keep recieved non-string inputs {non_strings}"
         return is_whitelisted(hits) and not is_blacklisted(hits)
 
     return should_keep

--- a/short-read-mngs/idseq-dag/idseq_dag/util/parsing.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/util/parsing.py
@@ -155,11 +155,11 @@ class _HitSummarySchema:
     SCHEMA = [
         ("read_id", str),
         ("level", int),
-        ("taxid", int),
+        ("taxid", str),
         ("accession_id", str),
-        ("species_taxid", int),
-        ("genus_taxid", int),
-        ("family_taxid", int),
+        ("species_taxid", str),
+        ("genus_taxid", str),
+        ("family_taxid", str),
     ]
 
 class HitSummaryReader(_HitSummarySchema, _TypedDictTSVReader):
@@ -175,9 +175,9 @@ class _HitSummaryMergedSchema:
     SCHEMA = _HitSummarySchema.SCHEMA + [
         ("contig_id", str),
         ("contig_accession_id", str),
-        ("contig_species_taxid", int),
-        ("contig_genus_taxid", int),
-        ("contig_family_taxid", int),
+        ("contig_species_taxid", str),
+        ("contig_genus_taxid", str),
+        ("contig_family_taxid", str),
         ("from_assembly", str),
         ("source_count_type", str),
     ]

--- a/short-read-mngs/idseq-dag/tests/unit/util/test_parsing.py
+++ b/short-read-mngs/idseq-dag/tests/unit/util/test_parsing.py
@@ -253,8 +253,8 @@ class TestBlastnOutput6NTRerankedWriter(unittest.TestCase):
 class TestHitSummaryReader(unittest.TestCase):
     def test_read(self):
         hit_summary_input = [
-            "read_id_1	10	20	accession_id_1	30	40	50",
-            "read_id_2	11	21		31	41	51", # missing accession_id
+            "read_id_1	10	taxid_1	accession_id_1	species_taxid_1	genus_taxid_1	family_taxid_1",
+            "read_id_2	11	taxid_2		species_taxid_2	genus_taxid_2	family_taxid_2", # missing accession_id
         ]
         rows = list(HitSummaryReader(hit_summary_input))
         self.assertEqual(len(rows), 2)
@@ -268,14 +268,14 @@ class TestHitSummaryReader(unittest.TestCase):
 
     def test_read_error_too_many_columns(self):
         hit_summary_input = [
-            "read_id_1	10	20	accession_id_1	30	40	50	60",
+            "read_id_1	10	taxid_1	accession_id_1	species_taxid_1	genus_taxid_1	family_taxid_1	60",
         ]
         with self.assertRaises(Exception):
             next(HitSummaryReader(hit_summary_input))
     
     def test_read_error_wrong_data_type(self):
         hit_summary_input = [
-            "read_id_1	10	not_num	accession_id_1	30	40	50",
+            "read_id_1	not_num	taxid_1	accession_id_1	species_taxid_1	genus_taxid_1	family_taxid_1",
         ]
         with self.assertRaises(Exception):
             next(HitSummaryReader(hit_summary_input))
@@ -288,11 +288,11 @@ class TestHitSummaryWriter(unittest.TestCase):
             writer.writerow({
                 "read_id": "read_id_1",
                 "level": 10,
-                "taxid": 20,
+                "taxid": "taxid_1",
                 "accession_id": "accession_id_1",
-                "species_taxid": 30,
-                "genus_taxid": 40,
-                "family_taxid": 60,
+                "species_taxid": "species_taxid_1",
+                "genus_taxid": "genus_taxid_1",
+                "family_taxid": "family_taxid_1",
             })
             writer.writerow({
                 "read_id": "2",

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -19,5 +19,5 @@ def test_RunValidateInput_invalid(
         json.dumps(inputs),
     )
 
-    assert False, outp["outputs"]
+    assert False, list(outp["outputs"].items())
 

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -5,6 +5,8 @@ import json
 def test_RunValidateInput_invalid(
     repo_dir, short_read_mngs_bench3_viral_outputs, miniwdl_inputs_outputs, miniwdl_run, RunFailed_stderr_msg
 ):
+    foo = os.listdir(short_read_mngs_bench3_viral_outputs["dir"])
+    assert False, foo
     # load the task's inputs from the end-to-end workflow test
     inputs, _ = miniwdl_inputs_outputs(
         os.path.join(short_read_mngs_bench3_viral_outputs["dir"], "call-non_host/call-RunAlignment")

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -19,5 +19,5 @@ def test_RunValidateInput_invalid(
         json.dumps(inputs),
     )
 
-    assert False, list(outp.keys())
+    assert False, outp["outputs"]
 

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -14,7 +14,7 @@ def test_RunValidateInput_invalid(
     outp = miniwdl_run(
         os.path.join(repo_dir, "short-read-mngs/host_filter.wdl"),
         "--task",
-        "RunAlignment",
+        "RunAlignment_rapsearch2_out",
         "-i",
         json.dumps(inputs),
     )

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -7,7 +7,7 @@ import tempfile
 def test_RunAlignmentBlacklist(
     repo_dir, short_read_mngs_bench3_viral_outputs, miniwdl_inputs_outputs, miniwdl_run, RunFailed_stderr_msg
 ):
-    task_name = "RunAlignment_rapsearch2_out"
+    task_name = "RunAlignment_gsnap_out"
     # load the task's inputs from the end-to-end workflow test
     inputs, _ = miniwdl_inputs_outputs(
         os.path.join(short_read_mngs_bench3_viral_outputs["dir"], "call-non_host_alignment", f"call-{task_name}")
@@ -21,7 +21,7 @@ def test_RunAlignmentBlacklist(
         json.dumps(inputs),
     )
 
-    with open(os.path.join(outp["dir"], outp["outputs"][f"{task_name}.rapsearch2_hitsummary_tab"])) as f:
+    with open(os.path.join(outp["dir"], outp["outputs"][f"{task_name}.gsnap_hitsummary_tab"])) as f:
         taxids = set(row[2] for row in csv.reader(f, delimiter="\t"))
 
     assert "37124" in taxids, "taxid should be in hitsummary unless filtered out"
@@ -40,8 +40,8 @@ def test_RunAlignmentBlacklist(
             json.dumps(inputs),
         )
 
-        hitsummary = os.path.join(outp["dir"], outp["outputs"][f"{task_name}.rapsearch2_hitsummary_tab"])
-        deduped = os.path.join(outp["dir"], outp["outputs"][f"{task_name}.rapsearch2_deduped_m8"])
+        hitsummary = os.path.join(outp["dir"], outp["outputs"][f"{task_name}.gsnap_hitsummary_tab"])
+        deduped = os.path.join(outp["dir"], outp["outputs"][f"{task_name}.gsnap_deduped_m8"])
 
         with open(hitsummary) as f:
             taxids = set(row[2] for row in csv.reader(f, delimiter="\t"))
@@ -57,7 +57,7 @@ def test_RunAlignmentBlacklist(
 def test_RunAlignmentDeuterostomeFilter(
     repo_dir, short_read_mngs_bench3_viral_outputs, miniwdl_inputs_outputs, miniwdl_run, RunFailed_stderr_msg
 ):
-    task_name = "RunAlignment_rapsearch2_out"
+    task_name = "RunAlignment_gsnap_out"
     # load the task's inputs from the end-to-end workflow test
     inputs, _ = miniwdl_inputs_outputs(
         os.path.join(short_read_mngs_bench3_viral_outputs["dir"], "call-non_host_alignment", f"call-{task_name}")
@@ -71,7 +71,7 @@ def test_RunAlignmentDeuterostomeFilter(
         json.dumps(inputs),
     )
 
-    with open(os.path.join(outp["dir"], outp["outputs"][f"{task_name}.rapsearch2_hitsummary_tab"])) as f:
+    with open(os.path.join(outp["dir"], outp["outputs"][f"{task_name}.gsnap_hitsummary_tab"])) as f:
         taxids = set(row[2] for row in csv.reader(f, delimiter="\t"))
 
     assert "37124" in taxids, "taxid should be in hitsummary unless filtered out"
@@ -91,8 +91,8 @@ def test_RunAlignmentDeuterostomeFilter(
             json.dumps(inputs),
         )
 
-        hitsummary = os.path.join(outp["dir"], outp["outputs"][f"{task_name}.rapsearch2_hitsummary_tab"])
-        deduped = os.path.join(outp["dir"], outp["outputs"][f"{task_name}.rapsearch2_deduped_m8"])
+        hitsummary = os.path.join(outp["dir"], outp["outputs"][f"{task_name}.gsnap_hitsummary_tab"])
+        deduped = os.path.join(outp["dir"], outp["outputs"][f"{task_name}.gsnap_deduped_m8"])
 
         with open(hitsummary) as f:
             taxids = set(row[2] for row in csv.reader(f, delimiter="\t"))

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -22,6 +22,6 @@ def test_RunValidateInput_invalid(
     )
 
     with open(os.path.join(outp["dir"], outp["outputs"][f"{task_name}.rapsearch2_m8"])) as f:
-        taxids = [row[2] for row in csv.reader(f)]
+        taxids = [row[2] for row in csv.reader(f, delimiter="\t")]
     assert False, ", ".join(taxids)
 

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -5,11 +5,9 @@ import json
 def test_RunValidateInput_invalid(
     repo_dir, short_read_mngs_bench3_viral_outputs, miniwdl_inputs_outputs, miniwdl_run, RunFailed_stderr_msg
 ):
-    foo = os.listdir(os.path.join(short_read_mngs_bench3_viral_outputs["dir"], "call-non_host_alignment"))
-    assert False, foo
     # load the task's inputs from the end-to-end workflow test
     inputs, _ = miniwdl_inputs_outputs(
-        os.path.join(short_read_mngs_bench3_viral_outputs["dir"], "call-non_host_alignment/call-RunAlignment")
+        os.path.join(short_read_mngs_bench3_viral_outputs["dir"], "call-non_host_alignment/call-RunAlignment_rapsearch2_out")
     )
 
     # run the task with the manipulated inputs, expecting an error exit status

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -28,7 +28,7 @@ def test_RunAlignmentBlacklist(
     assert "2169701" in taxids, "taxid should be in hitsummary unless filtered out"
 
     with tempfile.NamedTemporaryFile(prefix=os.path.dirname(__file__), mode="w") as blacklist_file:
-        blacklist_file.writelines(["37124", "2169701"])
+        blacklist_file.writelines(["37124\n", "2169701\n"])
         blacklist_file.seek(0)
         blacklist_file.writelines
         inputs["taxon_blacklist"] = blacklist_file.name
@@ -79,7 +79,7 @@ def test_RunAlignmentDeuterostomeFilter(
     assert "2169701" in taxids, "taxid should be in hitsummary unless filtered out"
 
     with tempfile.NamedTemporaryFile(prefix=os.path.dirname(__file__), mode="w") as deuterostome_file:
-        deuterostome_file.writelines(["37124", "2169701"])
+        deuterostome_file.writelines(["37124\n", "2169701\n"])
         deuterostome_file.seek(0)
         inputs["deuterostome_db"] = deuterostome_file.name
         inputs["use_deuterostome_filter"] = True

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -1,5 +1,6 @@
 import os
 import json
+import csv
 
 
 def test_RunValidateInput_invalid(
@@ -20,7 +21,7 @@ def test_RunValidateInput_invalid(
         json.dumps(inputs),
     )
 
-    with open(os.path.join(outp["dir"], outp["outputs"][f"{task_name}.rapsearch2_m8"])) as f:
-        taxids = [row for row in f]
+    with open(os.path.join(outp["dir"], outp["outputs"][f"{task_name}.rapsearch2_hitsummary_tab"])) as f:
+        taxids = [row[2] for row in csv.reader(f, delimiter="\t")]
     assert False, ", ".join(taxids)
 

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -21,7 +21,7 @@ def test_RunValidateInput_invalid(
         json.dumps(inputs),
     )
 
-    with open(os.path.join(outp["dir"], f"{task_name}.rapsearch2_m8")) as f:
+    with open(os.path.join(outp["dir"], outp["outputs"][f"{task_name}.rapsearch2_m8"])) as f:
         taxids = [row[2] for row in csv.reader(f)]
     assert False, ", ".join(taxids)
 

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -7,7 +7,7 @@ def test_RunValidateInput_invalid(
 ):
     # load the task's inputs from the end-to-end workflow test
     inputs, _ = miniwdl_inputs_outputs(
-        os.path.join(short_read_mngs_bench3_viral_outputs["dir"], "call-non_host_alignment/call-RunAlignment")
+        os.path.join(short_read_mngs_bench3_viral_outputs["dir"], "call-non_host/call-RunAlignment")
     )
 
     # run the task with the manipulated inputs, expecting an error exit status
@@ -17,6 +17,5 @@ def test_RunValidateInput_invalid(
         "RunAlignment",
         "-i",
         json.dumps(inputs),
-        returncode=0,
     )
 

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -1,23 +1,27 @@
 import os
 import json
+import csv
 
 
 def test_RunValidateInput_invalid(
     repo_dir, short_read_mngs_bench3_viral_outputs, miniwdl_inputs_outputs, miniwdl_run, RunFailed_stderr_msg
 ):
+    task_name = "RunAlignment_rapsearch2_out"
     # load the task's inputs from the end-to-end workflow test
     inputs, _ = miniwdl_inputs_outputs(
-        os.path.join(short_read_mngs_bench3_viral_outputs["dir"], "call-non_host_alignment/call-RunAlignment_rapsearch2_out")
+        os.path.join(short_read_mngs_bench3_viral_outputs["dir"], "call-non_host_alignment", f"call-{task_name}")
     )
 
     # run the task with the manipulated inputs, expecting an error exit status
     outp = miniwdl_run(
         os.path.join(repo_dir, "short-read-mngs/non_host_alignment.wdl"),
         "--task",
-        "RunAlignment_rapsearch2_out",
+        task_name,
         "-i",
         json.dumps(inputs),
     )
 
-    assert False, list(outp["outputs"].items())
+    with open(os.path.join(outp["dir"], f"{task_name}.rapsearch2_m8") as f:
+        taxids = [row[2] for row in csv.reader(f)]
+    assert False, ", ".join(taxids)
 

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -27,6 +27,9 @@ def test_RunAlignmentBlacklist(
     assert "37124" in taxids, "taxid should be in hitsummary unless filtered out"
     assert "2169701" in taxids, "taxid should be in hitsummary unless filtered out"
 
+    for path in outp["outputs"].values():
+        if path:
+            os.remove(path)
 
     with tempfile.NamedTemporaryFile(prefix=os.path.dirname(__file__), mode="w") as blacklist_file:
         blacklist_file.writelines(["37124", "2169701"])
@@ -77,6 +80,9 @@ def test_RunAlignmentDeuterostomeFilter(
     assert "37124" in taxids, "taxid should be in hitsummary unless filtered out"
     assert "2169701" in taxids, "taxid should be in hitsummary unless filtered out"
 
+    for path in outp["outputs"].values():
+        if path:
+            os.remove(path)
 
     with tempfile.NamedTemporaryFile(prefix=os.path.dirname(__file__), mode="w") as deuterostome_file:
         deuterostome_file.writelines(["37124", "2169701"])

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -19,5 +19,5 @@ def test_RunValidateInput_invalid(
         json.dumps(inputs),
     )
 
-    assert False, outp
+    assert False, list(outp.keys())
 

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -25,7 +25,6 @@ def test_RunAlignmentBlacklist(
         taxids = set(row[2] for row in csv.reader(f, delimiter="\t"))
 
     assert "37124" in taxids, "taxid should be in hitsummary unless filtered out"
-    assert "2169701" in taxids, "taxid should be in hitsummary unless filtered out"
 
     with tempfile.NamedTemporaryFile(prefix=os.path.dirname(__file__), mode="w") as blacklist_file:
         blacklist_file.writelines(["37124\n", "2169701\n"])
@@ -76,7 +75,6 @@ def test_RunAlignmentDeuterostomeFilter(
         taxids = set(row[2] for row in csv.reader(f, delimiter="\t"))
 
     assert "37124" in taxids, "taxid should be in hitsummary unless filtered out"
-    assert "2169701" in taxids, "taxid should be in hitsummary unless filtered out"
 
     with tempfile.NamedTemporaryFile(prefix=os.path.dirname(__file__), mode="w") as deuterostome_file:
         deuterostome_file.writelines(["37124\n", "2169701\n"])

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -24,8 +24,9 @@ def test_RunAlignmentBlacklist(
     with open(os.path.join(outp["dir"], outp["outputs"][f"{task_name}.gsnap_hitsummary_tab"])) as f:
         taxids = set(row[2] for row in csv.reader(f, delimiter="\t"))
 
-    assert "37124" in taxids, "taxid should be in hitsummary unless filtered out"
-    assert "2169701" in taxids, "taxid should be in hitsummary unless filtered out"
+    # TODO: (tmorse)
+    # assert "37124" in taxids, "taxid should be in hitsummary unless filtered out"
+    # assert "2169701" in taxids, "taxid should be in hitsummary unless filtered out"
 
     for path in outp["outputs"].values():
         if path:
@@ -77,8 +78,9 @@ def test_RunAlignmentDeuterostomeFilter(
     with open(os.path.join(outp["dir"], outp["outputs"][f"{task_name}.gsnap_hitsummary_tab"])) as f:
         taxids = set(row[2] for row in csv.reader(f, delimiter="\t"))
 
-    assert "37124" in taxids, "taxid should be in hitsummary unless filtered out"
-    assert "2169701" in taxids, "taxid should be in hitsummary unless filtered out"
+    # TODO: (tmorse)
+    # assert "37124" in taxids, "taxid should be in hitsummary unless filtered out"
+    # assert "2169701" in taxids, "taxid should be in hitsummary unless filtered out"
 
     for path in outp["outputs"].values():
         if path:

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -5,11 +5,11 @@ import json
 def test_RunValidateInput_invalid(
     repo_dir, short_read_mngs_bench3_viral_outputs, miniwdl_inputs_outputs, miniwdl_run, RunFailed_stderr_msg
 ):
-    foo = os.listdir(short_read_mngs_bench3_viral_outputs["dir"])
+    foo = os.listdir(os.path.join(short_read_mngs_bench3_viral_outputs["dir"], "call-non_host_alignment")
     assert False, foo
     # load the task's inputs from the end-to-end workflow test
     inputs, _ = miniwdl_inputs_outputs(
-        os.path.join(short_read_mngs_bench3_viral_outputs["dir"], "call-non_host/call-RunAlignment")
+        os.path.join(short_read_mngs_bench3_viral_outputs["dir"], "call-non_host_alignment/call-RunAlignment")
     )
 
     # run the task with the manipulated inputs, expecting an error exit status

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -30,7 +30,7 @@ def test_RunAlignmentBlacklist(
 
     with tempfile.NamedTemporaryFile("w") as blacklist_file:
         blacklist_file.writelines(["37124", "2169701"])
-        inputs["taxon_blacklist"] = f.name
+        inputs["taxon_blacklist"] = blacklist_file.name
 
         outp = miniwdl_run(
             os.path.join(repo_dir, "short-read-mngs/non_host_alignment.wdl"),

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -28,9 +28,60 @@ def test_RunAlignmentBlacklist(
     assert "2169701" in taxids, "taxid should be in hitsummary unless filtered out"
 
 
-    with tempfile.NamedTemporaryFile("w") as blacklist_file:
+    with tempfile.NamedTemporaryFile(prefix=os.path.dirname(__file__), mode="w") as blacklist_file:
         blacklist_file.writelines(["37124", "2169701"])
         inputs["taxon_blacklist"] = blacklist_file.name
+
+        outp = miniwdl_run(
+            os.path.join(repo_dir, "short-read-mngs/non_host_alignment.wdl"),
+            "--task",
+            task_name,
+            "-i",
+            json.dumps(inputs),
+        )
+
+        hitsummary = os.path.join(outp["dir"], outp["outputs"][f"{task_name}.rapsearch2_hitsummary_tab"])
+        deduped = os.path.join(outp["dir"], outp["outputs"][f"{task_name}.rapsearch2_deduped_m8"])
+
+        with open(hitsummary) as f:
+            taxids = set(row[2] for row in csv.reader(f, delimiter="\t"))
+
+        assert "37124" not in taxids, "taxid should be filtered out"
+        assert "2169701" not in taxids, "taxid should be filtered out"
+
+        with open(hitsummary) as hf, open(deduped) as df:
+            rows = zip(csv.reader(hf, delimiter="\t"), csv.reader(df, delimiter="\t"))
+            assert all(hrow[0] == drow[0] for hrow, drow in rows), "hitsummary and deduped output should be aligned"
+
+
+def test_RunAlignmentDeuterostomeFilter(
+    repo_dir, short_read_mngs_bench3_viral_outputs, miniwdl_inputs_outputs, miniwdl_run, RunFailed_stderr_msg
+):
+    task_name = "RunAlignment_rapsearch2_out"
+    # load the task's inputs from the end-to-end workflow test
+    inputs, _ = miniwdl_inputs_outputs(
+        os.path.join(short_read_mngs_bench3_viral_outputs["dir"], "call-non_host_alignment", f"call-{task_name}")
+    )
+
+    outp = miniwdl_run(
+        os.path.join(repo_dir, "short-read-mngs/non_host_alignment.wdl"),
+        "--task",
+        task_name,
+        "-i",
+        json.dumps(inputs),
+    )
+
+    with open(os.path.join(outp["dir"], outp["outputs"][f"{task_name}.rapsearch2_hitsummary_tab"])) as f:
+        taxids = set(row[2] for row in csv.reader(f, delimiter="\t"))
+
+    assert "37124" in taxids, "taxid should be in hitsummary unless filtered out"
+    assert "2169701" in taxids, "taxid should be in hitsummary unless filtered out"
+
+
+    with tempfile.NamedTemporaryFile(prefix=os.path.dirname(__file__), mode="w") as deuterostome_file:
+        deuterostome_file.writelines(["37124", "2169701"])
+        inputs["deuterostome_db"] = deuterostome_file.name
+        inputs["use_deuterostome_filter"] = True
 
         outp = miniwdl_run(
             os.path.join(repo_dir, "short-read-mngs/non_host_alignment.wdl"),

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -12,7 +12,7 @@ def test_RunValidateInput_invalid(
 
     # run the task with the manipulated inputs, expecting an error exit status
     outp = miniwdl_run(
-        os.path.join(repo_dir, "short-read-mngs/host_filter.wdl"),
+        os.path.join(repo_dir, "short-read-mngs/non_host_alignment.wdl"),
         "--task",
         "RunAlignment_rapsearch2_out",
         "-i",

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -19,3 +19,5 @@ def test_RunValidateInput_invalid(
         json.dumps(inputs),
     )
 
+    assert False, outp
+

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -1,9 +1,10 @@
 import os
 import json
 import csv
+import tempfile
 
 
-def test_RunValidateInput_invalid(
+def test_RunAlignmentBlacklist(
     repo_dir, short_read_mngs_bench3_viral_outputs, miniwdl_inputs_outputs, miniwdl_run, RunFailed_stderr_msg
 ):
     task_name = "RunAlignment_rapsearch2_out"
@@ -12,7 +13,6 @@ def test_RunValidateInput_invalid(
         os.path.join(short_read_mngs_bench3_viral_outputs["dir"], "call-non_host_alignment", f"call-{task_name}")
     )
 
-    # run the task with the manipulated inputs, expecting an error exit status
     outp = miniwdl_run(
         os.path.join(repo_dir, "short-read-mngs/non_host_alignment.wdl"),
         "--task",
@@ -22,6 +22,34 @@ def test_RunValidateInput_invalid(
     )
 
     with open(os.path.join(outp["dir"], outp["outputs"][f"{task_name}.rapsearch2_hitsummary_tab"])) as f:
-        taxids = [row[2] for row in csv.reader(f, delimiter="\t")]
-    assert False, ", ".join(taxids)
+        taxids = set(row[2] for row in csv.reader(f, delimiter="\t"))
+
+    assert "37124" in taxids, "taxid should be in hitsummary unless filtered out"
+    assert "2169701" in taxids, "taxid should be in hitsummary unless filtered out"
+
+
+    with tempfile.NamedTemporaryFile("w") as blacklist_file:
+        blacklist_file.writelines(["37124", "2169701"])
+        inputs["taxon_blacklist"] = f.name
+
+        outp = miniwdl_run(
+            os.path.join(repo_dir, "short-read-mngs/non_host_alignment.wdl"),
+            "--task",
+            task_name,
+            "-i",
+            json.dumps(inputs),
+        )
+
+        hitsummary = os.path.join(outp["dir"], outp["outputs"][f"{task_name}.rapsearch2_hitsummary_tab"])
+        deduped = os.path.join(outp["dir"], outp["outputs"][f"{task_name}.rapsearch2_deduped_m8"])
+
+        with open(hitsummary) as f:
+            taxids = set(row[2] for row in csv.reader(f, delimiter="\t"))
+
+        assert "37124" not in taxids, "taxid should be filtered out"
+        assert "2169701" not in taxids, "taxid should be filtered out"
+
+        with open(hitsummary) as hf, open(deduped) as df:
+            rows = zip(csv.reader(hf, delimiter="\t"), csv.reader(df, delimiter="\t"))
+            assert all(hrow[0] == drow[0] for hrow, drow in rows), "hitsummary and deduped output should be aligned"
 

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -5,7 +5,7 @@ import json
 def test_RunValidateInput_invalid(
     repo_dir, short_read_mngs_bench3_viral_outputs, miniwdl_inputs_outputs, miniwdl_run, RunFailed_stderr_msg
 ):
-    foo = os.listdir(os.path.join(short_read_mngs_bench3_viral_outputs["dir"], "call-non_host_alignment")
+    foo = os.listdir(os.path.join(short_read_mngs_bench3_viral_outputs["dir"], "call-non_host_alignment"))
     assert False, foo
     # load the task's inputs from the end-to-end workflow test
     inputs, _ = miniwdl_inputs_outputs(

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -24,16 +24,13 @@ def test_RunAlignmentBlacklist(
     with open(os.path.join(outp["dir"], outp["outputs"][f"{task_name}.gsnap_hitsummary_tab"])) as f:
         taxids = set(row[2] for row in csv.reader(f, delimiter="\t"))
 
-    # TODO: (tmorse)
-    # assert "37124" in taxids, "taxid should be in hitsummary unless filtered out"
-    # assert "2169701" in taxids, "taxid should be in hitsummary unless filtered out"
-
-    for path in outp["outputs"].values():
-        if path:
-            os.remove(path)
+    assert "37124" in taxids, "taxid should be in hitsummary unless filtered out"
+    assert "2169701" in taxids, "taxid should be in hitsummary unless filtered out"
 
     with tempfile.NamedTemporaryFile(prefix=os.path.dirname(__file__), mode="w") as blacklist_file:
         blacklist_file.writelines(["37124", "2169701"])
+        blacklist_file.seek(0)
+        blacklist_file.writelines
         inputs["taxon_blacklist"] = blacklist_file.name
 
         outp = miniwdl_run(
@@ -78,16 +75,12 @@ def test_RunAlignmentDeuterostomeFilter(
     with open(os.path.join(outp["dir"], outp["outputs"][f"{task_name}.gsnap_hitsummary_tab"])) as f:
         taxids = set(row[2] for row in csv.reader(f, delimiter="\t"))
 
-    # TODO: (tmorse)
-    # assert "37124" in taxids, "taxid should be in hitsummary unless filtered out"
-    # assert "2169701" in taxids, "taxid should be in hitsummary unless filtered out"
-
-    for path in outp["outputs"].values():
-        if path:
-            os.remove(path)
+    assert "37124" in taxids, "taxid should be in hitsummary unless filtered out"
+    assert "2169701" in taxids, "taxid should be in hitsummary unless filtered out"
 
     with tempfile.NamedTemporaryFile(prefix=os.path.dirname(__file__), mode="w") as deuterostome_file:
         deuterostome_file.writelines(["37124", "2169701"])
+        deuterostome_file.seek(0)
         inputs["deuterostome_db"] = deuterostome_file.name
         inputs["use_deuterostome_filter"] = True
 

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -25,9 +25,10 @@ def test_RunAlignmentBlacklist(
         taxids = set(row[2] for row in csv.reader(f, delimiter="\t"))
 
     assert "37124" in taxids, "taxid should be in hitsummary unless filtered out"
+    assert "1273712" in taxids, "taxid should be in hitsummary unless filtered out"
 
     with tempfile.NamedTemporaryFile(prefix=os.path.dirname(__file__), mode="w") as blacklist_file:
-        blacklist_file.writelines(["37124\n", "2169701\n"])
+        blacklist_file.writelines(["37124\n", "1273712\n"])
         blacklist_file.seek(0)
         blacklist_file.writelines
         inputs["taxon_blacklist"] = blacklist_file.name
@@ -47,7 +48,7 @@ def test_RunAlignmentBlacklist(
             taxids = set(row[2] for row in csv.reader(f, delimiter="\t"))
 
         assert "37124" not in taxids, "taxid should be filtered out"
-        assert "2169701" not in taxids, "taxid should be filtered out"
+        assert "1273712" not in taxids, "taxid should be filtered out"
 
         with open(hitsummary) as hf, open(deduped) as df:
             rows = zip(csv.reader(hf, delimiter="\t"), csv.reader(df, delimiter="\t"))
@@ -75,9 +76,10 @@ def test_RunAlignmentDeuterostomeFilter(
         taxids = set(row[2] for row in csv.reader(f, delimiter="\t"))
 
     assert "37124" in taxids, "taxid should be in hitsummary unless filtered out"
+    assert "1273712" in taxids, "taxid should be in hitsummary unless filtered out"
 
     with tempfile.NamedTemporaryFile(prefix=os.path.dirname(__file__), mode="w") as deuterostome_file:
-        deuterostome_file.writelines(["37124\n", "2169701\n"])
+        deuterostome_file.writelines(["37124\n", "1273712\n"])
         deuterostome_file.seek(0)
         inputs["deuterostome_db"] = deuterostome_file.name
         inputs["use_deuterostome_filter"] = True
@@ -97,7 +99,7 @@ def test_RunAlignmentDeuterostomeFilter(
             taxids = set(row[2] for row in csv.reader(f, delimiter="\t"))
 
         assert "37124" not in taxids, "taxid should be filtered out"
-        assert "2169701" not in taxids, "taxid should be filtered out"
+        assert "1273712" not in taxids, "taxid should be filtered out"
 
         with open(hitsummary) as hf, open(deduped) as df:
             rows = zip(csv.reader(hf, delimiter="\t"), csv.reader(df, delimiter="\t"))

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -1,6 +1,5 @@
 import os
 import json
-import csv
 
 
 def test_RunValidateInput_invalid(
@@ -22,6 +21,6 @@ def test_RunValidateInput_invalid(
     )
 
     with open(os.path.join(outp["dir"], outp["outputs"][f"{task_name}.rapsearch2_m8"])) as f:
-        taxids = [row[2] for row in csv.reader(f, delimiter="\t")]
+        taxids = [row for row in f]
     assert False, ", ".join(taxids)
 

--- a/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
+++ b/tests/short-read-mngs/non_host_alignment/test_RunAlignment.py
@@ -21,7 +21,7 @@ def test_RunValidateInput_invalid(
         json.dumps(inputs),
     )
 
-    with open(os.path.join(outp["dir"], f"{task_name}.rapsearch2_m8") as f:
+    with open(os.path.join(outp["dir"], f"{task_name}.rapsearch2_m8")) as f:
         taxids = [row[2] for row in csv.reader(f)]
     assert False, ", ".join(taxids)
 

--- a/tests/short-read-mngs/test_RunAlignment.py
+++ b/tests/short-read-mngs/test_RunAlignment.py
@@ -1,0 +1,22 @@
+import os
+import json
+
+
+def test_RunValidateInput_invalid(
+    repo_dir, short_read_mngs_bench3_viral_outputs, miniwdl_inputs_outputs, miniwdl_run, RunFailed_stderr_msg
+):
+    # load the task's inputs from the end-to-end workflow test
+    inputs, _ = miniwdl_inputs_outputs(
+        os.path.join(short_read_mngs_bench3_viral_outputs["dir"], "call-non_host_alignment/call-RunAlignment")
+    )
+
+    # run the task with the manipulated inputs, expecting an error exit status
+    outp = miniwdl_run(
+        os.path.join(repo_dir, "short-read-mngs/host_filter.wdl"),
+        "--task",
+        "RunAlignment",
+        "-i",
+        json.dumps(inputs),
+        returncode=0,
+    )
+


### PR DESCRIPTION
This actually contains two changes, a bit confusing but one won't work without the other.

First, I make taxids all strings. We have a big problem in the codebase of taxids being strings/numbers. For filtering, they must be strings. In some places they had to be ints because we do math with them and compare them as numbers sometimes. I think a cleaner approach overall would actually be to make them always ints but it is much safer to go in the string direction since this is explicitly used in way more places and we very rarely do math on the ids.

Second, I filter out taxids from the hit summary from alignment. This has the effect of filtering them out of the refined hits ummary as well. It took a lot of analyzing the code to come to this conclusion but I am pretty confident about it at this point. I added an explainatory comment. In general no taxids will be in the refined hit summary if they are not in the hit summary.