### PR TITLE
Migrate status JSON files out of idseq-dag

### DIFF
--- a/short-read-mngs/experimental.wdl
+++ b/short-read-mngs/experimental.wdl
@@ -22,6 +22,7 @@ task GenerateTaxidFasta {
     --additional-attributes '{}'
   >>>
   output {
+    String step_description_md = read_string("taxid_fasta_out.description.md")
     File taxid_annot_fasta = "taxid_annot.fasta"
     File? output_read_count = "taxid_fasta_out.count"
   }
@@ -49,6 +50,7 @@ task GenerateTaxidLocator {
     --additional-attributes '{}'
   >>>
   output {
+    String step_description_md = read_string("taxid_locator_out.description.md")
     File taxid_annot_sorted_nt_fasta = "taxid_annot_sorted_nt.fasta"
     File taxid_locations_nt_json = "taxid_locations_nt.json"
     File taxid_annot_sorted_nr_fasta = "taxid_annot_sorted_nr.fasta"
@@ -103,6 +105,7 @@ task GenerateAlignmentViz {
     --additional-attributes '{"nt_db": "~{nt_db}"}'
   >>>
   output {
+    String step_description_md = read_string("alignment_viz_out.description.md")
     File align_viz_summary = "align_viz.summary"
     File? output_read_count = "alignment_viz_out.count"
     Array[File] align_viz = glob("align_viz/*.align_viz.json")
@@ -134,6 +137,7 @@ task RunSRST2 {
     --additional-attributes '{"min_cov": 0, "n_threads": 16, "file_ext": "~{file_ext}"}'
   >>>
   output {
+    String step_description_md = read_string("srst2_out.description.md")
     File out_log = "out.log"
     File out__genes__ARGannot_r2__results_txt = "out__genes__ARGannot_r2__results.txt"
     File out__fullgenes__ARGannot_r2__results_txt = "out__fullgenes__ARGannot_r2__results.txt"
@@ -173,6 +177,7 @@ task GenerateCoverageViz {
     --additional-attributes '{}'
   >>>
   output {
+    String step_description_md = read_string("coverage_viz_out.description.md")
     File coverage_viz_summary_json = "coverage_viz_summary.json"
     File? output_read_count = "coverage_viz_out.count"
     Array[File] coverage_viz = glob("coverage_viz/*_coverage_viz.json")
@@ -204,6 +209,7 @@ task NonhostFastq {
     --additional-attributes '{"use_taxon_whitelist": ~{use_taxon_whitelist}}'
   >>>
   output {
+    String step_description_md = read_string("nonhost_fastq_out.description.md")
     File nonhost_R1_fastq = "nonhost_R1.fastq"
     File? nonhost_R2_fastq = "nonhost_R2.fastq"
     File? output_read_count = "nonhost_fastq_out.count"

--- a/short-read-mngs/host_filter.wdl
+++ b/short-read-mngs/host_filter.wdl
@@ -21,6 +21,7 @@ task RunValidateInput {
     --additional-attributes '{"truncate_fragments_to": ~{max_input_fragments}, "file_ext": "~{file_ext}"}'
   >>>
   output {
+    String step_description_md = read_string("validate_input_out.description.md")
     File validate_input_summary_json = "validate_input_summary.json"
     File valid_input1_fastq = "valid_input1.fastq"
     File? valid_input2_fastq = "valid_input2.fastq"
@@ -55,6 +56,7 @@ task RunStar {
     --additional-attributes '{"output_gene_file": "reads_per_gene.star.tab", "nucleotide_type": "~{nucleotide_type}", "host_genome": "~{host_genome}", "output_metrics_file": "picard_insert_metrics.txt", "output_histogram_file": "insert_size_histogram.pdf"}'
   >>>
   output {
+    String step_description_md = read_string("star_out.description.md")
     File unmapped1_fastq = "unmapped1.fastq"
     File? unmapped2_fastq = "unmapped2.fastq"
     File? output_read_count = "star_out.count"
@@ -87,6 +89,7 @@ task RunTrimmomatic {
     --additional-attributes '{}'
   >>>
   output {
+    String step_description_md = read_string("trimmomatic_out.description.md")
     File trimmomatic1_fastq = "trimmomatic1.fastq"
     File? trimmomatic2_fastq = "trimmomatic2.fastq"
     File? output_read_count = "trimmomatic_out.count"
@@ -115,6 +118,7 @@ task RunPriceSeq {
     --additional-attributes '{}'
   >>>
   output {
+    String step_description_md = read_string("priceseq_out.description.md")
     File priceseq1_fa = "priceseq1.fa"
     File? priceseq2_fa = "priceseq2.fa"
     File? output_read_count = "priceseq_out.count"
@@ -143,6 +147,7 @@ task RunIDSeqDedup {
     --additional-attributes '{}'
   >>>
   output {
+    String step_description_md = read_string("idseq_dedup_out.description.md")
     File dedup1_fa = "dedup1.fa"
     File? dedup2_fa = "dedup2.fa"
     File duplicate_clusters_csv = "clusters.csv"
@@ -175,6 +180,7 @@ task RunLZW {
     --additional-attributes '{"thresholds": [0.45, 0.42], "threshold_readlength": 150}'
   >>>
   output {
+    String step_description_md = read_string("lzw_out.description.md")
     File lzw1_fa = "lzw1.fa"
     File? lzw2_fa = "lzw2.fa"
     File? output_read_count = "lzw_out.count"
@@ -207,6 +213,7 @@ task RunBowtie2_bowtie2_out {
     --additional-attributes '{"output_sam_file": "bowtie2.sam"}'
   >>>
   output {
+    String step_description_md = read_string("bowtie2_out.description.md")
     File bowtie2_1_fa = "bowtie2_1.fa"
     File? bowtie2_2_fa = "bowtie2_2.fa"
     File? bowtie2_merged_fa = "bowtie2_merged.fa"
@@ -240,6 +247,7 @@ task RunSubsample {
     --additional-attributes '{"max_fragments": ~{max_subsample_fragments}}'
   >>>
   output {
+    String step_description_md = read_string("subsampled_out.description.md")
     File subsampled_1_fa = "subsampled_1.fa"
     File? subsampled_2_fa = "subsampled_2.fa"
     File? subsampled_merged_fa = "subsampled_merged.fa"
@@ -275,6 +283,7 @@ task RunStarDownstream {
     --additional-attributes '{}'
   >>>
   output {
+    String step_description_md = read_string("star_human_out.description.md")
     File unmapped_human_1_fa = "unmapped_human_1.fa"
     File? unmapped_human_2_fa = "unmapped_human_2.fa"
     File? output_read_count = "star_human_out.count"
@@ -307,6 +316,7 @@ task RunBowtie2_bowtie2_human_out {
     --additional-attributes '{"output_sam_file": "bowtie2_human.sam"}'
   >>>
   output {
+    String step_description_md = read_string("bowtie2_human_out.description.md")
     File bowtie2_human_1_fa = "bowtie2_human_1.fa"
     File? bowtie2_human_2_fa = "bowtie2_human_2.fa"
     File? bowtie2_human_merged_fa = "bowtie2_human_merged.fa"
@@ -340,6 +350,7 @@ task RunGsnapFilter {
     --additional-attributes '{"output_sam_file": "gsnap_filter.sam"}'
   >>>
   output {
+    String step_description_md = read_string("gsnap_filter_out.description.md")
     File gsnap_filter_1_fa = "gsnap_filter_1.fa"
     File? gsnap_filter_2_fa = "gsnap_filter_2.fa"
     File? gsnap_filter_merged_fa = "gsnap_filter_merged.fa"

--- a/short-read-mngs/idseq-dag/idseq_dag/__main__.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/__main__.py
@@ -122,7 +122,7 @@ def run_step():
         except Exception:
             logging.error("Failed to update status to '%s'", s)
         traceback.print_exc()
-        exit(json.dumps(dict(wdl_error_message=True, error=type(e).__name__, cause=str(e))))
+        exit(json.dumps(dict(wdl_error_message=True, error=type(e).__name__, cause=str(e), step_description_md=step_instance.step_description())))
 
 
 if __name__ == "__main__":

--- a/short-read-mngs/idseq-dag/idseq_dag/__main__.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/__main__.py
@@ -106,6 +106,9 @@ def run_step():
                               max_fragments=step_instance.additional_attributes["truncate_fragments_to"])
 
         step_instance.validate_input_files()
+        with open(f"{args.step_name}.description.md", "wb") as outfile:
+            # write step_description (which subclasses may generate dynamically) to local file
+            outfile.write(step_instance.step_description().encode("utf-8"))
         step_instance.run()
         step_instance.count_reads()
         step_instance.save_counts()

--- a/short-read-mngs/idseq-dag/idseq_dag/__main__.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/__main__.py
@@ -105,20 +105,11 @@ def run_step():
             count_input_reads(input_files=step_instance.input_files_local,
                               max_fragments=step_instance.additional_attributes["truncate_fragments_to"])
 
-        step_instance.update_status_json_file("running")
         step_instance.validate_input_files()
         step_instance.run()
         step_instance.count_reads()
         step_instance.save_counts()
-        # temporary until we instrument miniwdl - not yet uploaded, but this is the final status
-        step_instance.update_status_json_file("uploaded")
     except Exception as e:
-        try:
-            # process exception for status reporting
-            s = "user_errored" if isinstance(e, idseq_dag.engine.pipeline_step.InvalidInputFileError) else "pipeline_errored"
-            step_instance.update_status_json_file(s)
-        except Exception:
-            logging.error("Failed to update status to '%s'", s)
         traceback.print_exc()
         exit(json.dumps(dict(wdl_error_message=True, error=type(e).__name__, cause=str(e))))
 

--- a/short-read-mngs/idseq-dag/idseq_dag/engine/pipeline_flow.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/engine/pipeline_flow.py
@@ -233,14 +233,6 @@ class PipelineFlow(object):
 
         idseq_dag.util.s3.upload_with_retries(local_input_errors_file, self.output_dir_s3 + "/")
 
-    def create_status_json_file(self):
-        """Create [stage name]_status.json, which will include step-level job status updates to be used in idseq-web."""
-        log.write(f"Creating {self.step_status_local}")
-
-        with open(self.step_status_local, 'w') as status_file:
-            json.dump({}, status_file)
-        idseq_dag.util.s3.upload_with_retries(self.step_status_local, self.output_dir_s3 + "/")
-
     def manage_reference_downloads_cache(self):
         command.make_dirs(PURGE_SENTINEL_DIR)
         command.touch(PURGE_SENTINEL)
@@ -283,7 +275,6 @@ class PipelineFlow(object):
                 if target_info['s3_downloadable']:
                     threading.Thread(target=self.fetch_target_from_s3, args=(target,)).start()
 
-        self.create_status_json_file()
         # Start initializing all the steps and start running them and wait until all of them are done
         step_instances = []
         step_status_lock = TraceLock(

--- a/short-read-mngs/idseq-dag/idseq_dag/engine/pipeline_step.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/engine/pipeline_step.py
@@ -227,8 +227,7 @@ class PipelineStep(object):
         self.status = StepStatus.FINISHED
 
         # write step_description (which subclasses may generate dynamically) to local file
-        descfile = os.path.join(self.output_dir_local, f"{self.name}.description.md")
-        with open(descfile, "w") as outfile:
+        with open(f"{self.name}.description.md", "w") as outfile:
             print(self.step_description(), file=outfile)
 
     def start(self):

--- a/short-read-mngs/idseq-dag/idseq_dag/engine/pipeline_step.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/engine/pipeline_step.py
@@ -226,6 +226,11 @@ class PipelineStep(object):
         self.upload_thread.start()
         self.status = StepStatus.FINISHED
 
+        # write step_description (which subclasses may generate dynamically) to local file
+        descfile = os.path.join(self.output_dir_local, f"{self.name}.description.md")
+        with open(descfile, "w") as outfile:
+            print(self.step_description(), file=outfile)
+
     def start(self):
         ''' function to be called after instantiation to start running the step '''
         self.exec_thread = threading.Thread(target=self.thread_run)

--- a/short-read-mngs/idseq-dag/idseq_dag/engine/pipeline_step.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/engine/pipeline_step.py
@@ -226,10 +226,6 @@ class PipelineStep(object):
         self.upload_thread.start()
         self.status = StepStatus.FINISHED
 
-        # write step_description (which subclasses may generate dynamically) to local file
-        with open(f"{self.name}.description.md", "w") as outfile:
-            print(self.step_description(), file=outfile)
-
     def start(self):
         ''' function to be called after instantiation to start running the step '''
         self.exec_thread = threading.Thread(target=self.thread_run)

--- a/short-read-mngs/non_host_alignment.wdl
+++ b/short-read-mngs/non_host_alignment.wdl
@@ -30,6 +30,7 @@ task RunAlignment_gsnap_out {
     --additional-attributes '{"alignment_algorithm": "gsnap", "index_dir_suffix": "~{index_dir_suffix}", "use_taxon_whitelist": ~{use_taxon_whitelist}, "run_locally": ~{run_locally} ~{if defined(genome_name) then ' , "genome_name": "~{genome_name}"' else ''} }'
   >>>
   output {
+    String step_description_md = read_string("gsnap_out.description.md")
     File gsnap_m8 = "gsnap.m8"
     File gsnap_deduped_m8 = "gsnap.deduped.m8"
     File gsnap_hitsummary_tab = "gsnap.hitsummary.tab"
@@ -68,6 +69,7 @@ task RunAlignment_rapsearch2_out {
     --additional-attributes '{"alignment_algorithm": "rapsearch2", "index_dir_suffix": "~{index_dir_suffix}", "use_taxon_whitelist": ~{use_taxon_whitelist}, "run_locally": ~{run_locally} }'
   >>>
   output {
+    String step_description_md = read_string("rapsearch2_out.description.md")
     File rapsearch2_m8 = "rapsearch2.m8"
     File rapsearch2_deduped_m8 = "rapsearch2.deduped.m8"
     File rapsearch2_hitsummary_tab = "rapsearch2.hitsummary.tab"
@@ -98,6 +100,7 @@ task CombineTaxonCounts {
     --additional-attributes '{}'
   >>>
   output {
+    String step_description_md = read_string("taxon_count_out.description.md")
     File taxon_counts_with_dcr_json = "taxon_counts_with_dcr.json"
     File? output_read_count = "taxon_count_out.count"
   }
@@ -135,6 +138,7 @@ task GenerateAnnotatedFasta {
     --additional-attributes '{}'
   >>>
   output {
+    String step_description_md = read_string("annotated_out.description.md")
     File annotated_merged_fa = "annotated_merged.fa"
     File unidentified_fa = "unidentified.fa"
     File? output_read_count = "annotated_out.count"

--- a/short-read-mngs/postprocess.wdl
+++ b/short-read-mngs/postprocess.wdl
@@ -20,6 +20,7 @@ task RunAssembly {
     --additional-attributes '{"memory": 200}'
   >>>
   output {
+    String step_description_md = read_string("assembly_out.description.md")
     File assembly_contigs_fasta = "assembly/contigs.fasta"
     File assembly_scaffolds_fasta = "assembly/scaffolds.fasta"
     File assembly_read_contig_sam = "assembly/read-contig.sam"
@@ -53,6 +54,7 @@ task GenerateCoverageStats {
     --additional-attributes '{}'
   >>>
   output {
+    String step_description_md = read_string("coverage_out.description.md")
     File assembly_contig_coverage_json = "assembly/contig_coverage.json"
     File assembly_contig_coverage_summary_csv = "assembly/contig_coverage_summary.csv"
     File? output_read_count = "coverage_out.count"
@@ -87,6 +89,7 @@ task DownloadAccessions_gsnap_accessions_out {
     --additional-attributes '{"db": "~{nt_db}", "db_type": "nt"}'
   >>>
   output {
+    String step_description_md = read_string("gsnap_accessions_out.description.md")
     File assembly_nt_refseq_fasta = "assembly/nt.refseq.fasta"
     File? output_read_count = "gsnap_accessions_out.count"
   }
@@ -120,6 +123,7 @@ task DownloadAccessions_rapsearch2_accessions_out {
     --additional-attributes '{"db": "~{nr_db}", "db_type": "nr"}'
   >>>
   output {
+    String step_description_md = read_string("rapsearch2_accessions_out.description.md")
     File assembly_nr_refseq_fasta = "assembly/nr.refseq.fasta"
     File? output_read_count = "rapsearch2_accessions_out.count"
   }
@@ -161,6 +165,7 @@ task BlastContigs_refined_gsnap_out {
     --additional-attributes '{"db_type": "nt", "use_taxon_whitelist": ~{use_taxon_whitelist}}'
   >>>
   output {
+    String step_description_md = read_string("refined_gsnap_out.description.md")
     File assembly_gsnap_blast_m8 = "assembly/gsnap.blast.m8"
     File assembly_gsnap_reassigned_m8 = "assembly/gsnap.reassigned.m8"
     File assembly_gsnap_hitsummary2_tab = "assembly/gsnap.hitsummary2.tab"
@@ -205,6 +210,7 @@ task BlastContigs_refined_rapsearch2_out {
     --additional-attributes '{"db_type": "nr", "use_taxon_whitelist": ~{use_taxon_whitelist}}'
   >>>
   output {
+    String step_description_md = read_string("refined_rapsearch2_out.description.md")
     File assembly_rapsearch2_blast_m8 = "assembly/rapsearch2.blast.m8"
     File assembly_rapsearch2_reassigned_m8 = "assembly/rapsearch2.reassigned.m8"
     File assembly_rapsearch2_hitsummary2_tab = "assembly/rapsearch2.hitsummary2.tab"
@@ -253,6 +259,7 @@ task ComputeMergedTaxonCounts {
   >>>
 
   output {
+    String step_description_md = read_string("compute_merged_taxon_counts_out.description.md")
     File merged_m8 = "merged.m8"
     File merged_hitsummary2_tab = "merged.hitsummary2.tab"
     File merged_taxon_counts_with_dcr_json = "merged_taxon_counts_with_dcr.json"
@@ -283,6 +290,7 @@ task CombineTaxonCounts {
     --additional-attributes '{}'
   >>>
   output {
+    String step_description_md = read_string("refined_taxon_count_out.description.md")
     File assembly_refined_taxon_counts_with_dcr_json = "assembly/refined_taxon_counts_with_dcr.json"
     File? output_read_count = "refined_taxon_count_out.count"
   }
@@ -310,6 +318,7 @@ task CombineJson {
     --additional-attributes '{}'
   >>>
   output {
+    String step_description_md = read_string("contig_summary_out.description.md")
     File assembly_combined_contig_summary_json = "assembly/combined_contig_summary.json"
     File? output_read_count = "contig_summary_out.count"
   }
@@ -351,6 +360,7 @@ task GenerateAnnotatedFasta {
     --additional-attributes '{}'
   >>>
   output {
+    String step_description_md = read_string("refined_annotated_out.description.md")
     File assembly_refined_annotated_merged_fa = "assembly/refined_annotated_merged.fa"
     File assembly_refined_unidentified_fa = "assembly/refined_unidentified.fa"
     File? output_read_count = "refined_annotated_out.count"
@@ -393,6 +403,7 @@ task GenerateTaxidFasta {
     --additional-attributes '{}'
   >>>
   output {
+    String step_description_md = read_string("refined_taxid_fasta_out.description.md")
     File assembly_refined_taxid_annot_fasta = "assembly/refined_taxid_annot.fasta"
     File? output_read_count = "refined_taxid_fasta_out.count"
   }
@@ -420,6 +431,7 @@ task GenerateTaxidLocator {
     --additional-attributes '{}'
   >>>
   output {
+    String step_description_md = read_string("refined_taxid_locator_out.description.md")
     File assembly_refined_taxid_annot_sorted_nt_fasta = "assembly/refined_taxid_annot_sorted_nt.fasta"
     File assembly_refined_taxid_locations_nt_json = "assembly/refined_taxid_locations_nt.json"
     File assembly_refined_taxid_annot_sorted_nr_fasta = "assembly/refined_taxid_annot_sorted_nr.fasta"


### PR DESCRIPTION
Delete the code for creating these JSON files (to be read by webapp to display pipeline status) from idseq-dag, in favor of posting them from a miniwdl plugin.

The status JSON includes a markdown description for each step, which in some cases idseq-dag customized dynamically to reflect details of the specific inputs. We keep that idseq-dag logic and transmit the description through a WDL String output from each task to be read by the plugin.