### PR TITLE
short-read-mngs auto_benchmark: measure precision/recall wrt taxa truth sets

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ ruamel.yaml
 taxadb
 boto3
 requests
+sklearn

--- a/tests/short-read-mngs/auto_benchmark/README.md
+++ b/tests/short-read-mngs/auto_benchmark/README.md
@@ -107,7 +107,7 @@ docker run -v $(pwd):/mnt \
         /mnt/idseq-workflows/tests/short-read-mngs/auto_benchmark/short-read-mngs-benchmarks.ipynb
 ```
 
-Then find `idseq-short-read-mngs-benchmarks.html` in your working directory! (Note: when using the viral databases, the precision-recall curves compared to the truth sets are very poor, correctly so because the simulated datasets inlcude non-viral species.)
+Then find `idseq-short-read-mngs-benchmarks.html` in your working directory! (Note: when using the viral databases, the precision-recall curves compared to the truth sets are very poor, correctly so because the simulated datasets include non-viral species.)
 
 Change "viral" to "full" if you used the full-sized databases. Strike `--no-input` to include the notebook's Python code in the HTML report.
 

--- a/tests/short-read-mngs/auto_benchmark/README.md
+++ b/tests/short-read-mngs/auto_benchmark/README.md
@@ -1,8 +1,10 @@
 # short-read-mngs auto benchmarks
 
-This subdirectory has scripts and reference materials for "drift detection" in short-read-mngs pipeline results.
+This subdirectory has scripts and reference materials for benchmarking the short-read-mngs pipeline. On the one hand, it compares the identified taxa to respective "truth" for a set of test samples sourced from simulation tools and the metagenomics literature. On the other hand, it compares detailed results (read counts, rPM, etc.) between different versions of the pipeline, to detect more-subtle changes that might not be obvious in the truth comparison.
 
-1. [**benchmarks.yml**](benchmarks.yml): catalogue of test scenarios, including benchmark samples (FASTQs), reference databases, and pipeline settings
+The moving parts include:
+
+1. [**benchmarks.yml**](benchmarks.yml): catalogue of test scenarios, including benchmark samples (FASTQs), taxa truth sets, reference databases, and pipeline settings
 2. **run_local.py**: run one or more of the scenarios locally
 3. **run_dev.py**: submit one or more of the scenarios to the idseq-dev SFN-WDL backend
 4. **harvest.py**: summarize results of either runner script into a JSON file
@@ -98,20 +100,20 @@ Finally, run the Jupyter notebook to compare the generated results with the refe
 
 ```bash
 docker run -v $(pwd):/mnt \
-    --env HARVEST_DATA=/mnt/y_benchmarks.json \
+    --env HARVEST_DATA=/mnt/my_benchmarks.json \
     --env REF_LIB=/mnt/idseq-workflows/tests/short-read-mngs/auto_benchmark/ref_libs/default_viral \
     --env "RUN_NAME=default_viral_vA.B.C" \
     jupyter/scipy-notebook:latest jupyter nbconvert --execute --to html --no-input --output-dir /mnt \
         /mnt/idseq-workflows/tests/short-read-mngs/auto_benchmark/short-read-mngs-benchmarks.ipynb
 ```
 
-Then find `idseq-short-read-mngs-benchmarks.html` in your working directory!
+Then find `idseq-short-read-mngs-benchmarks.html` in your working directory! (Note: when using the viral databases, the precision-recall curves compared to the truth sets are very poor, correctly so because the simulated datasets inlcude non-viral species.)
 
 Change "viral" to "full" if you used the full-sized databases. Strike `--no-input` to include the notebook's Python code in the HTML report.
 
 ## Updating reference library
 
-Suppose the results in `my_benchmarks.json` differ in an expected way due to pipeline code changes. You can update a sample in the reference library like so:
+Suppose the results in `my_benchmarks.json` differ from the reference library in an expected way due to pipeline code changes. You can update the reference values like so:
 
 ```bash
 jq .idseq_bench_3 my_benchmarks.json > idseq-workflows/tests/short-read-mngs/auto_benchmark/ref_libs/default_viral/idseq_bench_3.json

--- a/tests/short-read-mngs/auto_benchmark/_util/__init__.py
+++ b/tests/short-read-mngs/auto_benchmark/_util/__init__.py
@@ -35,8 +35,8 @@ def adjusted_aupr(y_true, y_score, force_monotonic=False):
         precision = np.insert(precision, 0, 0)
 
     aupr = auc(recall, precision)
+    # figure which point on the P/R curve maximizes F1
     argmax_f1 = np.argmax((2 * p * r / (p + r) for (p, r) in zip(precision, recall)))
-    # precision & recall at point where their average is maximized
     return {
         k: v
         for k, v in {

--- a/tests/short-read-mngs/auto_benchmark/_util/__init__.py
+++ b/tests/short-read-mngs/auto_benchmark/_util/__init__.py
@@ -12,8 +12,10 @@ def load_benchmarks_yml():
 
 
 def adjusted_aupr(y_true, y_score, force_monotonic=False):
+    # precision_recall_curve wants nonzero probas_pred, so adjust any zeroes to epsilon
+    adjusted_y_score = [(1e-100 if score == 0 else score) for score in y_score]
     # Adapted from https://github.com/yesimon/metax_bakeoff_2019/blob/master/plotting/Metagenomics%20Bench.ipynb
-    original_precision, recall, thresholds = precision_recall_curve(y_true, y_score)
+    original_precision, recall, thresholds = precision_recall_curve(y_true, adjusted_y_score)
 
     precision = original_precision
     if force_monotonic:

--- a/tests/short-read-mngs/auto_benchmark/_util/__init__.py
+++ b/tests/short-read-mngs/auto_benchmark/_util/__init__.py
@@ -35,10 +35,18 @@ def adjusted_aupr(y_true, y_score, force_monotonic=False):
         precision = np.insert(precision, 0, 0)
 
     aupr = auc(recall, precision)
-    return {k: v for k, v in {
-        "aupr": aupr,
-        "original_precision": original_precision if force_monotonic else None,
-        "recall": recall,
-        "precision": precision,
-        "thresholds": thresholds,
-    }.items() if v is not None}
+    argmax_f1 = np.argmax((2 * p * r / (p + r) for (p, r) in zip(precision, recall)))
+    # precision & recall at point where their average is maximized
+    return {
+        k: v
+        for k, v in {
+            "aupr": aupr,
+            "original_precision": original_precision if force_monotonic else None,
+            "recall": recall,
+            "precision": precision,
+            "max_f1_recall": recall[argmax_f1],
+            "max_f1_precision": precision[argmax_f1],
+            "thresholds": thresholds,
+        }.items()
+        if v is not None
+    }

--- a/tests/short-read-mngs/auto_benchmark/_util/__init__.py
+++ b/tests/short-read-mngs/auto_benchmark/_util/__init__.py
@@ -1,7 +1,44 @@
-import os
-from ruamel.yaml import YAML
+from collections import defaultdict
 from pathlib import Path
+
+from ruamel.yaml import YAML
+from sklearn.metrics import auc, precision_recall_curve
+import numpy as np
+
 
 def load_benchmarks_yml():
     with open(Path(__file__).parent.parent / "benchmarks.yml") as benchmarks_yml:
         return YAML(typ="safe").load(benchmarks_yml.read())
+
+
+def adjusted_aupr(y_true, y_score, force_monotonic=False):
+    # Adapted from https://github.com/yesimon/metax_bakeoff_2019/blob/master/plotting/Metagenomics%20Bench.ipynb
+    original_precision, recall, thresholds = precision_recall_curve(y_true, y_score)
+
+    precision = original_precision
+    if force_monotonic:
+        # adjusts precision per each recall valu on the curve
+        # it guarantees that the curve is monotonic decreasing
+        precision_max_per_recall = defaultdict(float)
+        for r, p in zip(recall, original_precision):
+            precision_max_per_recall[r] = max(precision_max_per_recall[r], p)
+        adjusted_precision = []
+        for r, p in zip(recall, original_precision):
+            adjusted_precision.append(precision_max_per_recall[r])
+        precision = adjusted_precision
+
+    # force start at zero
+    if thresholds[0] == 0:
+        precision[0] = 0
+        recall[0] = recall[1]
+        recall = np.insert(recall, 0, 1)
+        precision = np.insert(precision, 0, 0)
+
+    aupr = auc(recall, precision)
+    return {k: v for k, v in {
+        "aupr": aupr,
+        "original_precision": original_precision if force_monotonic else None,
+        "recall": recall,
+        "precision": precision,
+        "thresholds": thresholds,
+    }.items() if v is not None}

--- a/tests/short-read-mngs/auto_benchmark/benchmarks.yml
+++ b/tests/short-read-mngs/auto_benchmark/benchmarks.yml
@@ -50,6 +50,7 @@ samples:
       fastqs_1: https://github.com/chanzuckerberg/idseq-workflows/raw/main/tests/short-read-mngs/norg_6__nacc_27__uniform_weight_per_organism__hiseq_reads__v6__R2.fastq.gz
       s3_fastqs_0: s3://idseq-bench/3/norg_6__nacc_27__uniform_weight_per_organism__hiseq_reads__v6__R1.fastq.gz
       s3_fastqs_1: s3://idseq-bench/3/norg_6__nacc_27__uniform_weight_per_organism__hiseq_reads__v6__R2.fastq.gz
+    truth: s3://idseq-bench/datasets/truth_files/norg_6__nacc_27__uniform_weight_per_organism__hiseq_reads__v6.TRUTH.txt
   idseq_bench_5:
     inputs:
       fastqs_0: https://github.com/chanzuckerberg/idseq-workflows/raw/main/tests/short-read-mngs/norg_13__nacc_35__uniform_weight_per_organism__hiseq_reads__v10__R1.fastq.gz

--- a/tests/short-read-mngs/auto_benchmark/harvest.py
+++ b/tests/short-read-mngs/auto_benchmark/harvest.py
@@ -365,7 +365,7 @@ def truth_aupr(classified_taxa, truth_taxa, total_reads):
     # Using raw abundances as proxies for confidence score per Ye2009 methodology
     # https://www.cell.com/cell/fulltext/S0092-8674(19)30775-5#fig2
     confidence_scores = [i["reads_dedup"] / total_reads for i in classified_taxa.values()]
-    confidence_scores += [1e-100] * len(missed_taxa)
+    confidence_scores += [0] * len(missed_taxa)
     return adjusted_aupr(correctness_labels, confidence_scores, force_monotonic=False)
 
 

--- a/tests/short-read-mngs/auto_benchmark/harvest.py
+++ b/tests/short-read-mngs/auto_benchmark/harvest.py
@@ -357,7 +357,7 @@ def read_truth_file(path):
         # All current benchmark datasets have truth data on species level only,
         # so we use this as a simplifying assumption downstream
         assert rank == "species"
-        taxon_abundances[int(taxid)] = float(abundance)
+        taxon_abundances[taxid] = float(abundance)
     return taxon_abundances
 
 

--- a/tests/short-read-mngs/auto_benchmark/harvest.py
+++ b/tests/short-read-mngs/auto_benchmark/harvest.py
@@ -155,14 +155,14 @@ def harvest_sample(sample, outputs_json, taxadb):
 
     nt_aupr = truth_aupr(ans["taxa"]["NT"], ans["truth"], total_reads)
     ans["NT_aupr"] = nt_aupr["aupr"]
-    ans["NT_max_f1_precision"] = nt_aupr["max_f1_precision"]
-    ans["NT_max_f1_recall"] = nt_aupr["max_f1_recall"]
+    ans["NT_precision"] = list(nt_aupr["precision"])
+    ans["NT_recall"] = list(nt_aupr["recall"])
     ans["NT_l2_norm"] = truth_l2_norm(ans["taxa"]["NT"], ans["truth"], total_reads)
 
     nr_aupr = truth_aupr(ans["taxa"]["NR"], ans["truth"], total_reads)
     ans["NR_aupr"] = nr_aupr["aupr"]
-    ans["NR_max_f1_precision"] = nr_aupr["max_f1_precision"]
-    ans["NR_max_f1_recall"] = nr_aupr["max_f1_recall"]
+    ans["NR_precision"] = list(nr_aupr["precision"])
+    ans["NR_recall"] = list(nr_aupr["recall"])
     ans["NR_l2_norm"] = truth_l2_norm(ans["taxa"]["NR"], ans["truth"], total_reads)
 
     return ans

--- a/tests/short-read-mngs/auto_benchmark/harvest.py
+++ b/tests/short-read-mngs/auto_benchmark/harvest.py
@@ -147,75 +147,24 @@ def harvest_sample(sample, outputs_json, taxadb):
     ans["taxa"]["NR"] = harvest_sample_taxon_counts(
         sample, outputs_json, contig_summary, contig_lengths, "NR", taxadb
     )
+
+    # compute figures of merit vs. truth dataset
     ans["truth"] = read_truth_file(BENCHMARKS["samples"][sample]["truth"])
 
-    """
-    From Ye et al. 2019:
-    Precision is the proportion of true positive species identified in the sample divided by the number of total species
-    identified.
-    Recall is the proportion of true positive species divided by the number of distinct species actually in the sample.
-    A potential drawback of AUPR is that it is biased toward low-precision, high-recall classifiers.
-    Classifiers that do not recall all of the ground-truth taxa are penalized with zero AUPR from the highest achieved
-    recall to 100% recall. For classifiers that do reach 100% recall, additional false positive taxon calls do not
-    further penalize the AUPR score.
-
-    In addition to considering the number of correctly identified species, it is also important to evaluate how
-    accurately the abundance of each species or genera in the resulting classification reflects the abundance of each
-    species in the original biological sample ("ground truth"). This is especially critical for applications such as
-    microbiome sequencing studies, where changes in population composition can confer phenotypic effects. Abundance can
-    be considered either as the relative abundance of reads from each taxa ("raw") or by inferring abundance of the
-    number of individuals from each taxa by correcting read counts for genome size ("corrected"). Some programs
-    incorporate a correction for genome length into abundance estimates; this calculation can also be manually performed
-    by reweighting the read counts after classification. Here we use raw abundance profiles unless correction is
-    performed automatically by the software, as in the case of PathSeq and Bracken.
-
-    To evaluate the accuracy of abundance profiles, we can calculate the pairwise distances between ground-truth
-    abundances and normalized abundance counts for each identified taxon at a given taxonomic level (e.g., species or
-    genus). For this, we calculate the L2 distance for a given dataset’s classified output as the straight-line distance
-    between the observed and true abundance vectors. We can also use this measure to compare abundance profiles between
-    classifiers by instead computing L2 distances between classified abundances for pairs of classifiers. Abundance
-    profile distance is more sensitive to accurate quantification of the highly abundant taxa present in the sample
-    (Aitchison, 1982; Quinn et al., 2018). High numbers of very-low-abundance false positives will not dramatically
-    affect the measure because they comprise only a small portion of the total abundance. For this reason, using such a
-    measure alongside AUPR, which is highly sensitive to classifiers’ performance in correctly identifying low-abundance
-    taxa, allows comprehensive evaluation of classifier performance.
-
-    The L2 distance should be considered as a representation of the abundance profiles. Because metagenomic abundance
-    profiles are proportional data and not absolute data, it is important to remember that many common distance metrics
-    (including L2 distance) are not true mathematical metrics in proportional space. Generally, in proportional data
-    analysis, a common method is to normalize proportions by using the centered log-ratio transform to calculate
-    distances. However, the output of these metagenomic classifiers includes many low-abundance false positives, leading
-    to sparse zero counts for many taxa across the different reports. The log-transform of these zero counts is
-    undefined unless arbitrary pseudocounts are added to each taxa, which can negatively bias accurate classifiers
-    because false positive taxa will have added counts. Another commonly used metric to compare abundance profiles is
-    the UniFrac distance, which considers both the abundance proportion of component taxa as well as the evolutionary
-    distance for incorrectly called taxa. However, using this metric is complicated by the difficulty in assessing
-    evolutionary distance between microbial species’ whole genomes.
-    """
-
-    nt_missed_taxa = [tax_id for tax_id in ans["truth"] if tax_id not in ans["taxa"]["NT"]]
-    nt_correctness_labels = [1 if tax_id in ans["truth"] else 0 for tax_id in ans["taxa"]["NT"]]
-    nt_correctness_labels += [1] * len(nt_missed_taxa)
     total_reads = ans["counts"]["subsampled_reads"] * (2 if ans["counts"]["paired"] else 1)
-    # Using raw abundances as proxies for confidence score per Ye2009 methodology
-    # https://www.cell.com/cell/fulltext/S0092-8674(19)30775-5#fig2
-    nt_confidence_scores = [i["reads_dedup"] / total_reads for i in ans["taxa"]["NT"].values()]
-    nt_confidence_scores += [1e-100] * len(nt_missed_taxa)
-    aupr_results = adjusted_aupr(nt_correctness_labels, nt_confidence_scores, force_monotonic=False)
-    ans["aupr"] = aupr_results["aupr"]
-    ans["max_f1_precision"] = aupr_results["max_f1_precision"]
-    ans["max_f1_recall"] = aupr_results["max_f1_recall"]
 
-    # TODO: use nr too
+    nt_aupr = truth_aupr(ans["taxa"]["NT"], ans["truth"], total_reads)
+    ans["NT_aupr"] = nt_aupr["aupr"]
+    ans["NT_max_f1_precision"] = nt_aupr["max_f1_precision"]
+    ans["NT_max_f1_recall"] = nt_aupr["max_f1_recall"]
+    ans["NT_l2_norm"] = truth_l2_norm(ans["taxa"]["NT"], ans["truth"], total_reads)
 
-    truth_sum = sum(ans["truth"].values())
-    relative_abundances_diff = [
-        ans["truth"][taxon] / truth_sum
-        - ans["taxa"]["NT"].get(taxon, {}).get("reads_dedup", 1e-100) / total_reads
-        for taxon in ans["truth"]
-    ]
+    nr_aupr = truth_aupr(ans["taxa"]["NR"], ans["truth"], total_reads)
+    ans["NR_aupr"] = nr_aupr["aupr"]
+    ans["NR_max_f1_precision"] = nr_aupr["max_f1_precision"]
+    ans["NR_max_f1_recall"] = nr_aupr["max_f1_recall"]
+    ans["NR_l2_norm"] = truth_l2_norm(ans["taxa"]["NR"], ans["truth"], total_reads)
 
-    ans["l2_norm"] = np.linalg.norm(relative_abundances_diff, ord=2)
     return ans
 
 
@@ -359,6 +308,78 @@ def read_truth_file(path):
         assert rank == "species"
         taxon_abundances[taxid] = float(abundance)
     return taxon_abundances
+
+
+"""
+From Ye et al. 2019:
+Precision is the proportion of true positive species identified in the sample divided by the number of total species
+identified.
+Recall is the proportion of true positive species divided by the number of distinct species actually in the sample.
+A potential drawback of AUPR is that it is biased toward low-precision, high-recall classifiers.
+Classifiers that do not recall all of the ground-truth taxa are penalized with zero AUPR from the highest achieved
+recall to 100% recall. For classifiers that do reach 100% recall, additional false positive taxon calls do not
+further penalize the AUPR score.
+
+In addition to considering the number of correctly identified species, it is also important to evaluate how
+accurately the abundance of each species or genera in the resulting classification reflects the abundance of each
+species in the original biological sample ("ground truth"). This is especially critical for applications such as
+microbiome sequencing studies, where changes in population composition can confer phenotypic effects. Abundance can
+be considered either as the relative abundance of reads from each taxa ("raw") or by inferring abundance of the
+number of individuals from each taxa by correcting read counts for genome size ("corrected"). Some programs
+incorporate a correction for genome length into abundance estimates; this calculation can also be manually performed
+by reweighting the read counts after classification. Here we use raw abundance profiles unless correction is
+performed automatically by the software, as in the case of PathSeq and Bracken.
+
+To evaluate the accuracy of abundance profiles, we can calculate the pairwise distances between ground-truth
+abundances and normalized abundance counts for each identified taxon at a given taxonomic level (e.g., species or
+genus). For this, we calculate the L2 distance for a given dataset’s classified output as the straight-line distance
+between the observed and true abundance vectors. We can also use this measure to compare abundance profiles between
+classifiers by instead computing L2 distances between classified abundances for pairs of classifiers. Abundance
+profile distance is more sensitive to accurate quantification of the highly abundant taxa present in the sample
+(Aitchison, 1982; Quinn et al., 2018). High numbers of very-low-abundance false positives will not dramatically
+affect the measure because they comprise only a small portion of the total abundance. For this reason, using such a
+measure alongside AUPR, which is highly sensitive to classifiers’ performance in correctly identifying low-abundance
+taxa, allows comprehensive evaluation of classifier performance.
+
+The L2 distance should be considered as a representation of the abundance profiles. Because metagenomic abundance
+profiles are proportional data and not absolute data, it is important to remember that many common distance metrics
+(including L2 distance) are not true mathematical metrics in proportional space. Generally, in proportional data
+analysis, a common method is to normalize proportions by using the centered log-ratio transform to calculate
+distances. However, the output of these metagenomic classifiers includes many low-abundance false positives, leading
+to sparse zero counts for many taxa across the different reports. The log-transform of these zero counts is
+undefined unless arbitrary pseudocounts are added to each taxa, which can negatively bias accurate classifiers
+because false positive taxa will have added counts. Another commonly used metric to compare abundance profiles is
+the UniFrac distance, which considers both the abundance proportion of component taxa as well as the evolutionary
+distance for incorrectly called taxa. However, using this metric is complicated by the difficulty in assessing
+evolutionary distance between microbial species’ whole genomes.
+"""
+
+
+def truth_aupr(classified_taxa, truth_taxa, total_reads):
+    """
+    Compute AUPR (and other metrics) of taxon classifications vs. truth data
+    """
+    missed_taxa = [tax_id for tax_id in truth_taxa if tax_id not in classified_taxa]
+    correctness_labels = [1 if tax_id in truth_taxa else 0 for tax_id in classified_taxa]
+    correctness_labels += [1] * len(missed_taxa)
+    # Using raw abundances as proxies for confidence score per Ye2009 methodology
+    # https://www.cell.com/cell/fulltext/S0092-8674(19)30775-5#fig2
+    confidence_scores = [i["reads_dedup"] / total_reads for i in classified_taxa.values()]
+    confidence_scores += [1e-100] * len(missed_taxa)
+    return adjusted_aupr(correctness_labels, confidence_scores, force_monotonic=False)
+
+
+def truth_l2_norm(classified_taxa, truth_taxa, total_reads):
+    """
+    Measure accuracy of taxa relative abundance (L2 norm of vector difference from truth vector)
+    """
+    truth_sum = sum(truth_taxa.values())
+    relative_abundances_diff = [
+        truth_taxa[taxon] / truth_sum
+        - classified_taxa.get(taxon, {}).get("reads_dedup", 1e-100) / total_reads
+        for taxon in truth_taxa
+    ]
+    return np.linalg.norm(relative_abundances_diff, ord=2)
 
 
 if __name__ == "__main__":

--- a/tests/short-read-mngs/auto_benchmark/harvest.py
+++ b/tests/short-read-mngs/auto_benchmark/harvest.py
@@ -191,7 +191,7 @@ def harvest_sample(sample, outputs_json, taxadb):
     the UniFrac distance, which considers both the abundance proportion of component taxa as well as the evolutionary
     distance for incorrectly called taxa. However, using this metric is complicated by the difficulty in assessing
     evolutionary distance between microbial species’ whole genomes.
-    '''
+x    '''
 
     nt_missed_taxa = [
         tax_id for tax_id in ans["truth"]
@@ -350,7 +350,7 @@ def contigs_stats(contig_lengths, ids=None):
 def read_truth_file(path):
     taxon_abundances = {}
     s3url = urlparse(path)
-    s3 = boto3.client('s3', config=BotocoreConfig(signature_version=BOTOCORE_UNSIGNED))
+    s3 = boto3.resource('s3', config=BotocoreConfig(signature_version=BOTOCORE_UNSIGNED))
     for line in s3.Object(s3url.netloc, s3url.path.lstrip("/")).get()["Body"].read().decode().splitlines():
         taxid, _, abundance, rank, species_name = line.split("\t")[:5]
         # All current benchmark datasets have truth data on species level only,

--- a/tests/short-read-mngs/auto_benchmark/short-read-mngs-benchmarks.ipynb
+++ b/tests/short-read-mngs/auto_benchmark/short-read-mngs-benchmarks.ipynb
@@ -170,7 +170,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## taxa abundance spectra & tables"
+    "## taxa abundance spectra & accuracy"
    ]
   },
   {
@@ -255,7 +255,8 @@
     "  * max_rPM = max between NR & NT\n",
     "  * red line: MIN_RPM cutoff for display in subsequent table.\n",
     "2. table of each species above MIN_RPM, with read & contig stats for NR & NT\n",
-    "  * green = within 1% of reference, yellow = within 10%, red = other."
+    "  * green = within 1% of reference, yellow = within 10%, red = other.\n",
+    "3. precision/recall curves for detected taxa vs. \"truth\" set"
    ]
   },
   {
@@ -276,7 +277,14 @@
     "    joined = joined[joined[\"max_rPM\"] >= min_rPM]\n",
     "    if ref_data:\n",
     "        joined = joined.style.apply(error_colors, axis=None)\n",
-    "    display(joined)"
+    "    display(joined)\n",
+    "    prdf = pd.concat([\n",
+    "        pd.DataFrame.from_dict({\"precision\":data[sample][\"NT_precision\"], \"recall\":data[sample][\"NT_recall\"], \"db\":[\"NT\"]*len(data[sample][\"NT_recall\"])}),\n",
+    "        pd.DataFrame.from_dict({\"precision\":data[sample][\"NR_precision\"], \"recall\":data[sample][\"NR_recall\"], \"db\":[\"NR\"]*len(data[sample][\"NR_recall\"])}),\n",
+    "    ])\n",
+    "    sns.lineplot(data=prdf, x=\"recall\", y=\"precision\", hue=\"db\", ci=None).set_title(f\"AUPR: NT={round(data[sample]['NT_aupr'],4)} NR={round(data[sample]['NR_aupr'],4)}\")\n",
+    "    plt.show()\n",
+    "\n"
    ]
   },
   {


### PR DESCRIPTION
@kislyuk @katrinakalantar Here's where we landed getting #79 to a solid checkpoint, with the precision/recall curves now rendered in the benchmarking jupyter notebook e.g.:

![image](https://user-images.githubusercontent.com/356550/108689601-5df5a800-749d-11eb-9050-99b7db12ecbd.png)

(These results look poor due to being run vs the viral-only databases in the [quick CI tests](https://github.com/chanzuckerberg/idseq-workflows/actions/workflows/short-read-mngs-viral-benchmarks.yml); I'm collating all the full-size results now)
