### PR TITLE
fix fasta writing bug

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ taxadb
 boto3
 requests
 sklearn
+biopython

--- a/short-read-mngs/idseq-dag/idseq_dag/steps/generate_taxid_fasta.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/steps/generate_taxid_fasta.py
@@ -56,7 +56,7 @@ class PipelineStepGenerateTaxidFasta(PipelineStep):
                 new_read_name = ('>' + ':'.join(fields) + '\n')
 
                 output_fa.write(new_read_name)
-                output_fa.write(read.sequence)
+                output_fa.write(read.sequence + "\n")
 
     def count_reads(self):
         pass

--- a/short-read-mngs/test/test_short_read_mngs.py
+++ b/short-read-mngs/test/test_short_read_mngs.py
@@ -1,6 +1,15 @@
 import json
 import atexit
+from Bio import SeqIO
 
+def is_valid_fasta(filename):
+    try:
+        with open(filename) as f:
+            for read in SeqIO.parse(f, "fasta"):
+                pass
+        return True
+    except:
+        return False
 
 def test_bench3_viral(short_read_mngs_bench3_viral_outputs):
     # short_read_mngs_bench3_viral_outputs is a fixture defined in ./conftest.py providing the JSON outputs of
@@ -20,4 +29,7 @@ def test_bench3_viral(short_read_mngs_bench3_viral_outputs):
     taxa = set(entry["tax_id"] for entry in taxon_counts)
     assert len(taxa) == 149
 
+    for filename in outp["outputs"]:
+        if filename.endswith(".fasta"):
+            assert is_valid_fasta(filename), f"{filename} is not a valid fasta file"
     # TODO: further correctness tests


### PR DESCRIPTION
This code was doing custom fasta parsing for reading and writing. I switched the reader to using our fasta iterator here which trims newlines. We had no writer and it was out of scope for the parsing refactor to switch to one so I left the writing as it is. Since there was transformation logic on the read name the newline was added back in so it still produced lines but 1 line per row and malformed. More evidence for why custom parsing can be dangerous. I wanted to limit the scope of this bugfix so I added the newline back instead of doing a fasta overhaul but one is needed.