### PR TITLE
update to catch vadr errors and associated unit tests

### DIFF
--- a/consensus-genome/run.wdl
+++ b/consensus-genome/run.wdl
@@ -36,7 +36,7 @@ workflow consensus_genome {
         Int normalise  = 1000
         # medaka_model: default is selected to support current ClearLabs workflow
         String medaka_model = "r941_min_high_g360"
-        String vadr_options = "-s -r --nomisc --mkey NC_045512 --lowsim5term 2 --lowsim3term 2 --fstlowthr 0.0 --alt_fail lowscore,fsthicnf,fstlocnf"
+        String vadr_options = "-s -r --nomisc --mkey NC_045512 --lowsim5term 2 --lowsim3term 2 --fstlowthr 0.0 --alt_fail lowscore,fsthicnf,fstlocnf --noseqnamemax"
         File vadr_model = "s3://idseq-public-references/consensus-genome/vadr-models-corona-1.1.3-1.tar.gz"
 
         # Illumina-specific parameters
@@ -945,14 +945,21 @@ task Vadr {
         tar xzvf "~{vadr_model}" -C /usr/local/share/vadr/models --strip-components 1
         # find available RAM
         RAM_MB=$(free -m | head -2 | tail -1 | awk '{print $2}')
-        # run VADR
-        v-annotate.pl ~{vadr_options} --mxsize $RAM_MB "~{assembly}" "vadr-output"
+        
+        {
+            # run VADR
+            v-annotate.pl ~{vadr_options} --mxsize $RAM_MB "~{assembly}" "vadr-output"        
+        } || {
+            echo "VADR encountered an error, handle it below."
+        }
 
-        # in validation, some samples fail with error: ERROR in cmalign_run(), cmalign failed in a bad way...
-        # ...see vadr-output/vadr-output.vadr.NC_045512.align.r1.s0.stdout for error output
-        if [ ! -e "vadr-output/vadr-output.vadr.sqc" ]; then
+        # in validation, some samples fail with errors: 
+        # ... ERROR in cmalign_run(), cmalign failed in a bad way...
+        # ... ERROR, at least one sequence name exceeds the maximum GenBank allowed length of 50...
+        # we want to capture VADR errors in JSON outputs but these should not cause the workflow to fail entirely
+        if [ `grep "\[fail\]" vadr-output/vadr-output.vadr.log | wc -l` -ge 1 ]; then
             set +x
-            export error=InsufficientReadsError cause="VADR failed to run"
+            export error=VADRError cause=`grep "ERROR" vadr-output/vadr-output.vadr.log`
             jq -nc ".wdl_error_message=true | .error=env.error | .cause=env.cause" > /dev/stderr
             exit 1
         fi

--- a/consensus-genome/run.wdl
+++ b/consensus-genome/run.wdl
@@ -952,21 +952,12 @@ task Vadr {
             # run VADR
             v-annotate.pl ~{vadr_options} --mxsize $RAM_MB "~{assembly}" "vadr-output"        
         } || {
+            # in validation, some samples fail with errors: 
+            # ... ERROR in cmalign_run(), cmalign failed in a bad way...
+            # ... ERROR, at least one sequence name exceeds the maximum GenBank allowed length of 50...
+            # we want to capture VADR errors in outputs but these should not cause the workflow to fail entirely
             grep "ERROR" vadr-output/vadr-output.vadr.log > vadr_error.txt
-            echo "VADR encountered an error, handle it below."
         }
-
-        # in validation, some samples fail with errors: 
-        # ... ERROR in cmalign_run(), cmalign failed in a bad way...
-        # ... ERROR, at least one sequence name exceeds the maximum GenBank allowed length of 50...
-        # we want to capture VADR errors in JSON outputs but these should not cause the workflow to fail entirely
-        #if [ `grep "\[fail\]" vadr-output/vadr-output.vadr.log | wc -l` -ge 1 ]; then
-        #    set +x
-        #    export error=VADRError cause=`grep "ERROR" vadr-output/vadr-output.vadr.log`
-        #    jq -nc ".wdl_error_message=true | .error=env.error | .cause=env.cause" > /dev/stderr
-        #    exit 1
-        #fi
-
     >>>
 
     output {

--- a/consensus-genome/test/test_wdl.py
+++ b/consensus-genome/test/test_wdl.py
@@ -81,6 +81,9 @@ class TestConsensusGenomes(TestCase):
         res = self.run_miniwdl(args=args)
         self.assertIn("consensus_genome.vadr_alerts_out", res["outputs"])
         self.assertIn("consensus_genome.vadr_alerts_out", res["outputs"])
+        print(res["outputs"])
+        print(res["outputs"]["consensus_genome.vadr_errors"])
+        self.assertEqual(res["outputs"]["consensus_genome.vadr_errors"], None)
         
     # test the depths associated with SNAP ivar trim -x 5 
     def test_sars_cov2_illumina_cg_snap(self):

--- a/consensus-genome/test/test_wdl.py
+++ b/consensus-genome/test/test_wdl.py
@@ -69,9 +69,10 @@ class TestConsensusGenomes(TestCase):
         fastqs_1 = os.path.join(os.path.dirname(__file__), "sample_sars-cov-2_paired_r2.fastq.gz")
         vadr_opts_string = "-s -r --nomisc --mkey NC_045512 --lowsim5term 2 --lowsim3term 2 --fstlowthr 0.0 --alt_fail lowscore,fsthicnf,fstlocnf"
         args = ["sample=test_sample_really_really_really_long_sample_name_over_50_chars", f"fastqs_0={fastqs_0}", f"fastqs_1={fastqs_1}", "technology=Illumina", f"vadr_options={vadr_opts_string}"]
-        with self.assertRaises(CalledProcessError) as ecm:
-            res = self.run_miniwdl(args=args)
-        self.assertRunFailed(ecm, task="Vadr", error="VADRError", cause="ERROR, at least one sequence name exceeds the maximum GenBank allowed length of 50:", error_without_failure=True)
+        res = self.run_miniwdl(args=args)
+        self.assertIn("consensus_genome.vadr_errors", res["outputs"])
+        self.assertEqual(res["outputs"]["consensus_genome.vadr_alerts_out"], None)
+        self.assertEqual(res["outputs"]["consensus_genome.vadr_quality_out"], None)
 
     def test_vadr_flag_works(self):
         fastqs_0 = os.path.join(os.path.dirname(__file__), "sample_sars-cov-2_paired_r1.fastq.gz")

--- a/consensus-genome/test/test_wdl.py
+++ b/consensus-genome/test/test_wdl.py
@@ -25,9 +25,10 @@ class TestConsensusGenomes(TestCase):
         res = check_output(cmd)
         return json.loads(res)
 
-    def assertRunFailed(self, ecm, task, error, cause):
+    def assertRunFailed(self, ecm, task, error, cause, error_without_failure = False):
         miniwdl_error = json.loads(ecm.exception.output)
-        self.assertEqual(miniwdl_error["error"], "RunFailed")
+        if not error_without_failure:
+            self.assertEqual(miniwdl_error["error"], "RunFailed")
         self.assertEqual(miniwdl_error["cause"]["error"], "CommandFailed")
         self.assertEqual(miniwdl_error["cause"]["run"], f"call-{task}")
         with open(miniwdl_error["cause"]["stderr_file"]) as fh:
@@ -62,6 +63,24 @@ class TestConsensusGenomes(TestCase):
             for filename in output:
                 self.assertGreater(os.path.getsize(filename), 0)
 
+    def test_vadr_error_caught(self):
+        # use the long filename error as a proxy for testing VADR error handling 
+        fastqs_0 = os.path.join(os.path.dirname(__file__), "sample_sars-cov-2_paired_r1.fastq.gz")
+        fastqs_1 = os.path.join(os.path.dirname(__file__), "sample_sars-cov-2_paired_r2.fastq.gz")
+        vadr_opts_string = "-s -r --nomisc --mkey NC_045512 --lowsim5term 2 --lowsim3term 2 --fstlowthr 0.0 --alt_fail lowscore,fsthicnf,fstlocnf"
+        args = ["sample=test_sample_really_really_really_long_sample_name_over_50_chars", f"fastqs_0={fastqs_0}", f"fastqs_1={fastqs_1}", "technology=Illumina", f"vadr_options={vadr_opts_string}"]
+        with self.assertRaises(CalledProcessError) as ecm:
+            res = self.run_miniwdl(args=args)
+        self.assertRunFailed(ecm, task="Vadr", error="VADRError", cause="ERROR, at least one sequence name exceeds the maximum GenBank allowed length of 50:", error_without_failure=True)
+
+    def test_vadr_flag_works(self):
+        fastqs_0 = os.path.join(os.path.dirname(__file__), "sample_sars-cov-2_paired_r1.fastq.gz")
+        fastqs_1 = os.path.join(os.path.dirname(__file__), "sample_sars-cov-2_paired_r2.fastq.gz")
+        args = ["sample=test_sample_really_really_really_long_sample_name_over_50_chars", f"fastqs_0={fastqs_0}", f"fastqs_1={fastqs_1}", "technology=Illumina"]
+        res = self.run_miniwdl(args=args)
+        self.assertIn("consensus_genome.vadr_alerts_out", res["outputs"])
+        self.assertIn("consensus_genome.vadr_alerts_out", res["outputs"])
+        
     # test the depths associated with SNAP ivar trim -x 5 
     def test_sars_cov2_illumina_cg_snap(self):
         fastqs_0 = os.path.join(os.path.dirname(__file__), "snap_top10k_R1_001.fastq.gz")

--- a/consensus-genome/test/test_wdl.py
+++ b/consensus-genome/test/test_wdl.py
@@ -56,7 +56,7 @@ class TestConsensusGenomes(TestCase):
         self.assertEqual(output_stats["ref_snps"], 7)
         self.assertEqual(output_stats["ref_mnps"], 0)
         for output_name, output in outputs.items():
-            if output_name in {"consensus_genome.minion_log"}:
+            if output_name in {"consensus_genome.minion_log", "consensus_genome.vadr_errors"}:
                 continue
             if not isinstance(output, list):
                 output = [output]
@@ -135,7 +135,8 @@ class TestConsensusGenomes(TestCase):
         for output_name, output in outputs.items():
             if output_name in {"consensus_genome.quantify_erccs_out_ercc_out",
                                "consensus_genome.filter_reads_out_filtered_fastqs",
-                               "consensus_genome.trim_reads_out_trimmed_fastqs"}:
+                               "consensus_genome.trim_reads_out_trimmed_fastqs",
+                               "consensus_genome.vadr_errors"}:
                 continue
             if not isinstance(output, list):
                 output = [output]


### PR DESCRIPTION
We were seeing sample failure events due to VADR throwing an error for long sample names: `ERROR, at least one sequence name exceeds the maximum GenBank allowed length of 50` 

VADR should not cause the pipeline to fail. Rather, the errors should be caught and propagated in .json while the pipeline continues. This PR addresses these issues as follows:

- Updating the `vadr_options` to use the `--noseqnamemax` flag so that it will not fail for long sample names
- Updating the Vadr step to  include better error handling that will correctly capture the error more accurately and allow the pipeline to continue
-  Added associated unit tests to 1. use the long sample names as a proxy for vadr failures to test the error handling, 2. ensure that the flag successfully eliminates this particular error.

This was tested via unit testing as well as through application to two separate samples.