### PR TITLE
reduce the nanopore workflow min_length parameter to accommodate ClearLabs samples in the interim 

### DIFF
--- a/consensus-genome/run.wdl
+++ b/consensus-genome/run.wdl
@@ -33,7 +33,7 @@ workflow consensus_genome {
         File primer_schemes = "s3://idseq-public-references/consensus-genome/artic-primer-schemes.tar.gz"
         # filters in accordance with recommended parameters in ARTIC SARS-CoV-2 bioinformatics protocol are...
         # ...intended to remove obviously chimeric reads.
-        Int min_length = 350 # minimum length reduced to 350 to accomodate Clear Labs samples
+        Int min_length = 200 # minimum length reduced to 200 to accomodate Clear Labs samples
         Int max_length = 700
         # normalise: default is set to 1000 to avoid spurious indels observed in validation
         Int normalise  = 1000


### PR DESCRIPTION
Modify the default `min_length` parameter for nanopore sars-cov-2 consensus genome analysis to achieve higher coverage for ClearLabs samples, which tend to have a distribution of read lengths that include a significant number (> 50%) of reads with lengths below the initial 350 parameter value. 

This PR is to enable DPH users who are actively using the pipeline during the beta phase to achieve genomes of comparable quality. However, further validation and a parameter sweep will need to be done prior to v1 launch to ensure that this modification does not produce issues for standard ONT data. 