### PR TITLE
Bump taxoniq to v0.6.0

### DIFF
--- a/consensus-genome/Dockerfile
+++ b/consensus-genome/Dockerfile
@@ -102,8 +102,8 @@ RUN pip3 install ont-fast5-api parasail mappy pyspoa tensorflow https://github.c
 RUN pip3 install medaka --no-deps
 
 # General CG dependencies
-RUN pip3 install taxoniq==0.5.2 && \
+RUN pip3 install taxoniq==0.6.0 && \
     pip3 install --upgrade \
-    https://github.com/chanzuckerberg/taxoniq/releases/download/v0.5.2/ncbi_genbank_accession_db-2021.3.25-py3-none-any.whl \
-    https://github.com/chanzuckerberg/taxoniq/releases/download/v0.5.2/ncbi_genbank_accession_lengths-2021.3.25-py3-none-any.whl \
-    https://github.com/chanzuckerberg/taxoniq/releases/download/v0.5.2/ncbi_genbank_accession_offsets-2021.3.25-py3-none-any.whl
+    https://github.com/chanzuckerberg/taxoniq/releases/download/v0.6.0/ncbi_genbank_accession_db-2021.4.10-py3-none-any.whl \
+    https://github.com/chanzuckerberg/taxoniq/releases/download/v0.6.0/ncbi_genbank_accession_lengths-2021.4.10-py3-none-any.whl \
+    https://github.com/chanzuckerberg/taxoniq/releases/download/v0.6.0/ncbi_genbank_accession_offsets-2021.4.10-py3-none-any.whl

--- a/consensus-genome/test/test_wdl.py
+++ b/consensus-genome/test/test_wdl.py
@@ -211,7 +211,7 @@ class TestConsensusGenomes(WDLTestCase):
         self.assertEqual(output_stats["ercc_mapped_reads"], 0)
         self.assertEqual(output_stats["ref_snps"], 0)
         self.assertEqual(output_stats["ref_mnps"], 0)
-        self.assertEqual(output_stats["n_actg"], 15314)
+        self.assertEqual(output_stats["n_actg"], 15313)
         self.assertEqual(output_stats["n_missing"], 0)
         self.assertEqual(output_stats["n_gap"], 0)
         self.assertEqual(output_stats["n_ambiguous"], 4)

--- a/consensus-genome/test/test_wdl.py
+++ b/consensus-genome/test/test_wdl.py
@@ -214,7 +214,7 @@ class TestConsensusGenomes(WDLTestCase):
         self.assertEqual(output_stats["n_actg"], 15314)
         self.assertEqual(output_stats["n_missing"], 0)
         self.assertEqual(output_stats["n_gap"], 0)
-        self.assertEqual(output_stats["n_ambiguous"], 2)
+        self.assertEqual(output_stats["n_ambiguous"], 4)
 
         self.assertEqual(res["outputs"]["consensus_genome.vadr_alerts_out"], None)
         self.assertEqual(res["outputs"]["consensus_genome.vadr_quality_out"], None)

--- a/consensus-genome/test/test_wdl.py
+++ b/consensus-genome/test/test_wdl.py
@@ -212,7 +212,7 @@ class TestConsensusGenomes(WDLTestCase):
         self.assertEqual(output_stats["ref_snps"], 0)
         self.assertEqual(output_stats["ref_mnps"], 0)
         self.assertEqual(output_stats["n_actg"], 15313)
-        self.assertEqual(output_stats["n_missing"], 0)
+        self.assertEqual(output_stats["n_missing"], 1)
         self.assertEqual(output_stats["n_gap"], 0)
         self.assertEqual(output_stats["n_ambiguous"], 4)
 

--- a/consensus-genome/test/test_wdl.py
+++ b/consensus-genome/test/test_wdl.py
@@ -211,10 +211,10 @@ class TestConsensusGenomes(WDLTestCase):
         self.assertEqual(output_stats["ercc_mapped_reads"], 0)
         self.assertEqual(output_stats["ref_snps"], 0)
         self.assertEqual(output_stats["ref_mnps"], 0)
-        self.assertEqual(output_stats["n_actg"], 15311)
-        self.assertEqual(output_stats["n_missing"], 1)
+        self.assertEqual(output_stats["n_actg"], 15314)
+        self.assertEqual(output_stats["n_missing"], 0)
         self.assertEqual(output_stats["n_gap"], 0)
-        self.assertEqual(output_stats["n_ambiguous"], 4)
+        self.assertEqual(output_stats["n_ambiguous"], 2)
 
         self.assertEqual(res["outputs"]["consensus_genome.vadr_alerts_out"], None)
         self.assertEqual(res["outputs"]["consensus_genome.vadr_quality_out"], None)


### PR DESCRIPTION
Resolves a bug where taxoniq would report some sequences to be 1, 2, or 3 nt shorter than they really are (due to the intricacies of the NCBI BLAST nucleotide DB format).