### PR TITLE
raise proper insufficient reads error

### DIFF
--- a/short-read-mngs/idseq-dag/idseq_dag/util/fasta.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/util/fasta.py
@@ -3,6 +3,7 @@ from typing import Iterator, List, Tuple, NamedTuple
 import sys
 import os
 from subprocess import run
+from idseq_dag.exceptions import InsufficientReadsError
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
 
@@ -40,6 +41,8 @@ def input_file_type(input_file):
     ''' Check input file type based on first line of file. file needs to be uncompressed '''
     with open(input_file, 'r') as f:
         first_line = f.readline()
+    if not first_line:
+        raise InsufficientReadsError("Insufficient reads")
     if first_line[0] == '@':
         return 'fastq'
     elif first_line[0] == '>':


### PR DESCRIPTION
The only snag here is we don't know the step name in the error message, and it is in some of them. Though it should be fairly obvious which step this happens in. This will raise the correct error in STAR https://app.clubhouse.io/idseq/story/125231/handle-empty-files-when-checking-for-fasta-vs-fastq.