### PR TITLE
emit star logfile

### DIFF
--- a/short-read-mngs/host_filter.wdl
+++ b/short-read-mngs/host_filter.wdl
@@ -53,11 +53,12 @@ task RunStar {
     --output-files '[~{if length(valid_input_fastq) == 2 then '"unmapped1.fastq", "unmapped2.fastq"' else '"unmapped1.fastq"'}]' \
     --output-dir-s3 '~{s3_wd_uri}' \
     --additional-files '{"star_genome": "~{star_genome}"}' \
-    --additional-attributes '{"output_gene_file": "reads_per_gene.star.tab", "nucleotide_type": "~{nucleotide_type}", "host_genome": "~{host_genome}", "output_metrics_file": "picard_insert_metrics.txt", "output_histogram_file": "insert_size_histogram.pdf"}'
+    --additional-attributes '{"output_gene_file": "reads_per_gene.star.tab", "nucleotide_type": "~{nucleotide_type}", "host_genome": "~{host_genome}", "output_metrics_file": "picard_insert_metrics.txt", "output_histogram_file": "insert_size_histogram.pdf", "output_log_file": "Log.final.out"}'
   >>>
   output {
     String step_description_md = read_string("star_out.description.md")
     File unmapped1_fastq = "unmapped1.fastq"
+    File output_log_file = "Log.final.out"
     File? unmapped2_fastq = "unmapped2.fastq"
     File? output_read_count = "star_out.count"
     File? output_gene_file = "reads_per_gene.star.tab"
@@ -501,6 +502,7 @@ workflow idseq_host_filter {
     File? validate_input_out_count = RunValidateInput.output_read_count
     File star_out_unmapped1_fastq = RunStar.unmapped1_fastq
     File? star_out_unmapped2_fastq = RunStar.unmapped2_fastq
+    File? star_out_log_file = RunStar.output_log_file
     File? star_out_count = RunStar.output_read_count
     File trimmomatic_out_trimmomatic1_fastq = RunTrimmomatic.trimmomatic1_fastq
     File? trimmomatic_out_trimmomatic2_fastq = RunTrimmomatic.trimmomatic2_fastq

--- a/short-read-mngs/idseq-dag/idseq_dag/steps/run_star.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/steps/run_star.py
@@ -145,6 +145,7 @@ class PipelineStepRunStar(PipelineStep):
 
         output_files_local = self.output_files_local()
         output_gene_file = self.additional_attributes.get("output_gene_file")
+        output_log_file = self.additional_attributes.get("output_log_file")
 
         genome_dir = s3.fetch_reference(
             self.additional_files["star_genome"],
@@ -196,6 +197,11 @@ class PipelineStepRunStar(PipelineStep):
                                          output_gene_file)
                     command.move_file(gene_count_file, moved)
                     self.additional_output_files_hidden.append(moved)
+
+                log_file = os.path.join(tmp, "Log.final.out")
+                if os.path.isfile(log_file):
+                    moved = os.path.join(self.output_dir_local, output_log_file)
+                    command.move_file(log_file, moved)
 
                 # STAR names the output BAM file Aligned.out.bam without TranscriptomeSAM and
                 #  Aligned.toTranscriptome.out.bam with  TranscriptomeSAM, this doesn't

--- a/short-read-mngs/test/host_filter/test_RunStar.py
+++ b/short-read-mngs/test/host_filter/test_RunStar.py
@@ -20,5 +20,5 @@ def test_RunStar_outputs_logfile(util, short_read_mngs_bench3_viral_outputs):
     )
 
     # verify Log.final.out is emitted
-    logfile = outp["outputs"]["Log.final.out"]
+    logfile = outp["outputs"]["RunStar.output_log_file"]
     assert os.path.exists(logfile)

--- a/short-read-mngs/test/host_filter/test_RunStar.py
+++ b/short-read-mngs/test/host_filter/test_RunStar.py
@@ -21,5 +21,5 @@ def test_RunStar_outputs_logfile(util, short_read_mngs_bench3_viral_outputs):
     )
 
     # verify Log.final.out is emitted
-    logfile = outp["outputs"]["RunStar.output_log_file"]
+    logfile = outp["outputs"]["Log.final.out"]
     assert os.path.exists(logfile)

--- a/short-read-mngs/test/host_filter/test_RunStar.py
+++ b/short-read-mngs/test/host_filter/test_RunStar.py
@@ -17,7 +17,6 @@ def test_RunStar_outputs_logfile(util, short_read_mngs_bench3_viral_outputs):
         "RunStar",
         "-i",
         json.dumps(inputs),
-        returncode=1,
     )
 
     # verify Log.final.out is emitted

--- a/short-read-mngs/test/host_filter/test_RunStar.py
+++ b/short-read-mngs/test/host_filter/test_RunStar.py
@@ -1,0 +1,25 @@
+import os
+import json
+
+
+def test_RunStar_outputs_logfile(util, short_read_mngs_bench3_viral_outputs):
+    # load the task's inputs from the end-to-end workflow test
+    inputs, _ = util.miniwdl_inputs_outputs(
+        os.path.join(
+            short_read_mngs_bench3_viral_outputs["dir"], "call-host_filter/call-RunStar"
+        )
+    )
+
+    # run the task with the manipulated inputs, expecting an error exit status
+    outp = util.miniwdl_run(
+        util.repo_dir() / "short-read-mngs/host_filter.wdl",
+        "--task",
+        "RunStar",
+        "-i",
+        json.dumps(inputs),
+        returncode=1,
+    )
+
+    # verify Log.final.out is emitted
+    logfile = outp["outputs"]["RunStar.output_log_file"]
+    assert os.path.exists(logfile)


### PR DESCRIPTION
Move one of star's outputs into the output directory and add it as an output in the WDL.

Includes a test for file presence to verify the file is being transferred.

I want to refactor the star step to dramatically simplify it but that is a larger task than I have time for this sprint so I opted to change as little as possible without making things worse.