### PR TITLE
Santitize inputs for safe CSVs

### DIFF
--- a/short-read-mngs/idseq-dag/idseq_dag/steps/run_validate_input.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/steps/run_validate_input.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 
 from idseq_dag.engine.pipeline_step import PipelineStep
 from idseq_dag.exceptions import InvalidFileFormatError, InsufficientReadsError
@@ -8,6 +9,8 @@ import idseq_dag.util.command_patterns as command_patterns
 import idseq_dag.util.count as count
 import idseq_dag.util.validate_constants as vc
 import idseq_dag.util.s3 as s3
+
+bad_csv_character_re = re.compile("[=+-@|]")
 
 class PipelineStepRunValidateInput(PipelineStep):
     """ Validates that the input files are .fastq format and truncates to 75 million fragments
@@ -144,6 +147,10 @@ class PipelineStepRunValidateInput(PipelineStep):
                     if num_fragments == 1:
                         raise InsufficientReadsError("The input file contains 0 reads")
                     break
+                
+                # These identifiers are used in a CSV downstream
+                # For security reasons we must strip out characters that can be used for explouts
+                identifier_l = bad_csv_character_re.sub(identifier_l, '')
 
                 read_l = input_f.readline()
                 if len(read_l) == 0:  # unexpected EOF
@@ -224,6 +231,7 @@ class PipelineStepRunValidateInput(PipelineStep):
                 identifier_l = next_line
                 if len(identifier_l) == 0:  # EOF
                     break
+                identifier_l = re.replace()
 
                 read_l = input_f.readline()
                 if len(read_l) == 0:

--- a/short-read-mngs/idseq-dag/idseq_dag/steps/run_validate_input.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/steps/run_validate_input.py
@@ -150,7 +150,7 @@ class PipelineStepRunValidateInput(PipelineStep):
 
                 # These identifiers are used in a CSV downstream
                 # For security reasons we must strip out characters that can be used for explouts
-                identifier_l = bad_csv_character_re.sub(identifier_l, '')
+                identifier_l = identifier_l[0] + bad_csv_character_re.sub(identifier_l[1:], '')
 
                 read_l = input_f.readline()
                 if len(read_l) == 0:  # unexpected EOF

--- a/short-read-mngs/idseq-dag/idseq_dag/steps/run_validate_input.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/steps/run_validate_input.py
@@ -231,7 +231,6 @@ class PipelineStepRunValidateInput(PipelineStep):
                 identifier_l = next_line
                 if len(identifier_l) == 0:  # EOF
                     break
-                identifier_l = re.replace()
 
                 read_l = input_f.readline()
                 if len(read_l) == 0:

--- a/short-read-mngs/idseq-dag/idseq_dag/steps/run_validate_input.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/steps/run_validate_input.py
@@ -147,7 +147,7 @@ class PipelineStepRunValidateInput(PipelineStep):
                     if num_fragments == 1:
                         raise InsufficientReadsError("The input file contains 0 reads")
                     break
-                
+
                 # These identifiers are used in a CSV downstream
                 # For security reasons we must strip out characters that can be used for explouts
                 identifier_l = bad_csv_character_re.sub(identifier_l, '')

--- a/short-read-mngs/idseq-dag/idseq_dag/steps/run_validate_input.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/steps/run_validate_input.py
@@ -149,7 +149,7 @@ class PipelineStepRunValidateInput(PipelineStep):
                     break
 
                 # These identifiers are used in a CSV downstream
-                # For security reasons we must strip out characters that can be used for explouts
+                # For security reasons we must strip out characters that can be used for exploits
                 identifier_l = identifier_l[0] + bad_csv_character_re.sub(identifier_l[1:], '')
 
                 read_l = input_f.readline()

--- a/short-read-mngs/test/host_filter/test_RunValidateInput.py
+++ b/short-read-mngs/test/host_filter/test_RunValidateInput.py
@@ -44,8 +44,7 @@ def test_RunValidateInput_strip_bad_csv_characters(util, short_read_mngs_bench3_
     with tempfile.NamedTemporaryFile('wb') as input_fastq, gzip.open(inputs["fastqs"][0]) as good_fastq:
         for i, line in enumerate(good_fastq):
             if i == 0:
-                clean_line = line
-                dirty_line = clean_line.strip() + b"=+-@|\n"
+                dirty_line = line.strip() + b"=+-@|\n"
                 input_fastq.write(dirty_line)
             else:
                 input_fastq.write(line)
@@ -64,6 +63,5 @@ def test_RunValidateInput_strip_bad_csv_characters(util, short_read_mngs_bench3_
 
         bad = re.compile('[=+-@|]')
         with open(outp["outputs"]["RunValidateInput.valid_input1_fastq"]) as o:
-            for line in o:
-                if line.startswith('@'):
-                    assert not bad.match(line[1:]), f"found bad csv character in line: '{line}'"
+            first = o.read()
+            assert not bad.match(first[1:]), f"found bad csv character in line: '{first}'"

--- a/short-read-mngs/test/host_filter/test_RunValidateInput.py
+++ b/short-read-mngs/test/host_filter/test_RunValidateInput.py
@@ -49,7 +49,6 @@ def test_RunValidateInput_strip_bad_csv_characters(util, short_read_mngs_bench3_
             else:
                 input_fastq.write(line)
 
-
         # override fastqs to test
         inputs["fastqs"] = [input_fastq.name]
 

--- a/short-read-mngs/test/host_filter/test_RunValidateInput.py
+++ b/short-read-mngs/test/host_filter/test_RunValidateInput.py
@@ -65,4 +65,5 @@ def test_RunValidateInput_strip_bad_csv_characters(util, short_read_mngs_bench3_
         bad = re.compile('[=+-@|]')
         with open(outp["outputs"]["RunValidateInput.valid_input1_fastq"]) as o:
             for line in o:
-                assert not bad.match(line[1:]), "found bad csv character in line"
+                if line.startswith('@'):
+                    assert not bad.match(line[1:]), f"found bad csv character in line: '{line}'"

--- a/short-read-mngs/test/host_filter/test_RunValidateInput.py
+++ b/short-read-mngs/test/host_filter/test_RunValidateInput.py
@@ -1,5 +1,6 @@
 import os
 import re
+import gzip
 import json
 import tempfile
 
@@ -40,7 +41,7 @@ def test_RunValidateInput_strip_bad_csv_characters(util, short_read_mngs_bench3_
         )
     )
 
-    with tempfile.NamedTemporaryFile('w') as input_fastq, open(inputs["fastqs"][0]) as good_fastq:
+    with tempfile.NamedTemporaryFile('w') as input_fastq, gzip.open(inputs["fastqs"][0], 'r') as good_fastq:
         for i, line in enumerate(good_fastq):
             if i == 0:
                 clean_line = line

--- a/short-read-mngs/test/host_filter/test_RunValidateInput.py
+++ b/short-read-mngs/test/host_filter/test_RunValidateInput.py
@@ -30,6 +30,7 @@ def test_RunValidateInput_invalid(util, short_read_mngs_bench3_viral_outputs):
     assert err["wdl_error_message"]
     assert err["error"] == "InvalidFileFormatError"
 
+
 def test_RunValidateInput_strip_bad_csv_characters(util, short_read_mngs_bench3_viral_outputs):
     # load the task's inputs from the end-to-end workflow test
     inputs, _ = util.miniwdl_inputs_outputs(

--- a/short-read-mngs/test/host_filter/test_RunValidateInput.py
+++ b/short-read-mngs/test/host_filter/test_RunValidateInput.py
@@ -1,5 +1,6 @@
 import os
 import json
+import tempfile
 
 
 def test_RunValidateInput_invalid(util, short_read_mngs_bench3_viral_outputs):
@@ -28,3 +29,33 @@ def test_RunValidateInput_invalid(util, short_read_mngs_bench3_viral_outputs):
     err = util.wdl_error_message(outp)
     assert err["wdl_error_message"]
     assert err["error"] == "InvalidFileFormatError"
+
+def test_RunValidateInput_strip_bad_csv_characters(util, short_read_mngs_bench3_viral_outputs):
+    # load the task's inputs from the end-to-end workflow test
+    inputs, _ = util.miniwdl_inputs_outputs(
+        os.path.join(
+            short_read_mngs_bench3_viral_outputs["dir"], "call-host_filter/call-RunValidateInput"
+        )
+    )
+
+    with tempfile.NamedTemporaryFile('w') as f:
+        f.writelines([
+            ">my-id@with|bad=chars+",
+            "ACTG",
+        ])
+
+        # override fastqs to test
+        inputs["fastqs"] = [f.name]
+
+        # run the task with the manipulated inputs, expecting an error exit status
+        outp = util.miniwdl_run(
+            util.repo_dir() / "short-read-mngs/host_filter.wdl",
+            "--task",
+            "RunValidateInput",
+            "-i",
+            json.dumps(inputs),
+        )
+
+        with open(outp["outputs"]["RunValidateInput."]) as o:
+            first = o.read()
+            assert first == ">myidwithbadchars", "should strip out bad csv characters"

--- a/short-read-mngs/test/host_filter/test_RunValidateInput.py
+++ b/short-read-mngs/test/host_filter/test_RunValidateInput.py
@@ -41,11 +41,11 @@ def test_RunValidateInput_strip_bad_csv_characters(util, short_read_mngs_bench3_
         )
     )
 
-    with tempfile.NamedTemporaryFile('w') as input_fastq, gzip.open(inputs["fastqs"][0], 'r') as good_fastq:
+    with tempfile.NamedTemporaryFile('wb') as input_fastq, gzip.open(inputs["fastqs"][0]) as good_fastq:
         for i, line in enumerate(good_fastq):
             if i == 0:
                 clean_line = line
-                dirty_line = clean_line.strip() + "=+-@|\n"
+                dirty_line = clean_line.strip() + b"=+-@|\n"
                 input_fastq.write(dirty_line)
             else:
                 input_fastq.write(line)

--- a/short-read-mngs/test/host_filter/test_RunValidateInput.py
+++ b/short-read-mngs/test/host_filter/test_RunValidateInput.py
@@ -63,5 +63,6 @@ def test_RunValidateInput_strip_bad_csv_characters(util, short_read_mngs_bench3_
 
         bad = re.compile('[=+-@|]')
         with open(outp["outputs"]["RunValidateInput.valid_input1_fastq"]) as o:
-            first = o.read()
-            assert not bad.match(first[1:]), f"found bad csv character in line: '{first}'"
+            for line in o:
+                if line.startswith('@'):
+                    assert not bad.search(line[1:]), f"found bad csv character in line: '{line}'"


### PR DESCRIPTION
At first I wanted to do this to the CSV directly. Unfortunately, I realized we use that CSV downstream for our counts so the identifiers must match. Though it is a bit indirect I think the only way forward is to do this in validate input or not make this CSV available for download at all. Some people may use these characters in their identifiers.