### PR TITLE
remove nt.refseq output

### DIFF
--- a/short-read-mngs/postprocess.wdl
+++ b/short-read-mngs/postprocess.wdl
@@ -666,7 +666,6 @@ workflow idseq_postprocess {
     File coverage_out_assembly_contig_coverage_json = GenerateCoverageStats.assembly_contig_coverage_json
     File coverage_out_assembly_contig_coverage_summary_csv = GenerateCoverageStats.assembly_contig_coverage_summary_csv
     File? coverage_out_count = GenerateCoverageStats.output_read_count
-    File gsnap_accessions_out_assembly_nt_refseq_fasta = DownloadAccessions_gsnap_accessions_out.assembly_nt_refseq_fasta
     File? gsnap_accessions_out_count = DownloadAccessions_gsnap_accessions_out.output_read_count
     File rapsearch2_accessions_out_assembly_nr_refseq_fasta = DownloadAccessions_rapsearch2_accessions_out.assembly_nr_refseq_fasta
     File? rapsearch2_accessions_out_count = DownloadAccessions_rapsearch2_accessions_out.output_read_count


### PR DESCRIPTION
I was going to fix this by combining steps but recently I have done some experimenting and it seems the viz is robust to changes in outputs. I think it is simpler and cleaner to just remove this as an output to save space. This is also a bit of a trial run for the valid inputs removal which needs to be done this way.