### PR TITLE
switch to initial space safety

### DIFF
--- a/short-read-mngs/idseq-dag/idseq_dag/steps/run_idseq_dedup.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/steps/run_idseq_dedup.py
@@ -63,11 +63,11 @@ class PipelineStepRunIDSeqDedup(PipelineStep):  # Deliberately not PipelineCount
             )
         )
 
-        # quote the csv with ' to guard against potential csv injection
+        # Add leading space to every cell in the CSV to guard against potential csv injection
         with open(duplicate_clusters_raw_path) as r, open(duplicate_clusters_path, 'w') as w:
             writer = csv.writer(w)
             for row in csv.reader(r):
-                writer.writerow(f"'{elem}'" for elem in row)
+                writer.writerow(" " + elem for elem in row)
 
         # Emit cluster sizes.  One line per cluster.  Format "<cluster_size> <cluster_read_id>".
         # This info is loaded in multiple subsequent steps using m8.load_duplicate_cluster_sizes,

--- a/short-read-mngs/idseq-dag/idseq_dag/util/idseq_dedup_clusters.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/util/idseq_dedup_clusters.py
@@ -12,7 +12,7 @@ def parse_clusters_file(
 ) -> Dict[str, Optional[List]]:
     clusters_dict = {}
     with open(idseq_dedup_clusters_path) as f:
-        for row in DictReader(f, quotechar="'"):
+        for row in DictReader(f, skipinitialspace=True):
             r_read_id, read_id = row["representative read id"], row["read id"]
             if r_read_id not in clusters_dict:
                 clusters_dict[r_read_id] = [1]

--- a/short-read-mngs/test/host_filter/test_RunIDSeqDedup.py
+++ b/short-read-mngs/test/host_filter/test_RunIDSeqDedup.py
@@ -21,8 +21,14 @@ def test_RunIDSeqDedup_safe_csv(util, short_read_mngs_bench3_viral_outputs):
 
     dups = outp["outputs"]["RunIDSeqDedup.duplicate_clusters_csv"]
 
+    # check we have an initial space to prevent CSV injection
     with open(dups) as f:
         for row in csv.reader(f):
             for elem in row:
-                # check for quotes that prevent csv injection
-                assert elem[0] == "'" and elem[-1] == "'", f"line not surrounded with ': {elem}"
+                assert elem[0] == " ", f"cell does not have initial space '{elem}'"
+
+    # check we can parse our CSV with skipinitialspace
+    with open(dups) as f:
+        for row in csv.reader(f, skipinitialspace=True):
+            for elem in row:
+                assert elem[0] != " ", f"initial space was not stripped from cell '{elem}'"


### PR DESCRIPTION
@jshoe pointed out that my implementation degraded user experience. This should be a better solution that balances user experience with parse-ability.

New tests too.

BTW the pipeline integration tests assure that the IDs are being found by steps since if one is ever not found the pipeline will crash.