### PR TITLE
short-read-mngs RunAssembly: contig length filter

### DIFF
--- a/short-read-mngs/Dockerfile
+++ b/short-read-mngs/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 ARG DEBIAN_FRONTEND=noninteractive
-ARG MINIWDL_VERSION=0.7.5
+ARG MINIWDL_VERSION=1.1.5
 
 LABEL maintainer="IDseq Team idseq-tech@chanzuckerberg.com"
 

--- a/short-read-mngs/idseq-dag/idseq_dag/steps/run_assembly.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/steps/run_assembly.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from idseq_dag.engine.pipeline_step import PipelineStep
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
+import idseq_dag.util.fasta as fasta
 
 from idseq_dag.util.m8 import MIN_CONTIG_SIZE
 from idseq_dag.util.count import get_read_cluster_size, load_duplicate_cluster_sizes, READ_COUNTING_MODE, ReadCountingMode
@@ -64,11 +65,13 @@ class PipelineStepRunAssembly(PipelineStep):
         duplicate_cluster_sizes_path, = self.input_files_local[1]
         assert duplicate_cluster_sizes_path.endswith(".tsv"), self.input_files_local[1]
 
-        assembled_contig, assembled_scaffold, bowtie_sam, contig_stats = self.output_files_local()
+        assembled_contig, assembled_contig_all, assembled_scaffold, bowtie_sam, contig_stats = self.output_files_local()
         read2contig = {}
         memory = self.additional_attributes.get('memory', 100)
-        self.assemble(input_fasta, input_fasta2, bowtie_fasta, duplicate_cluster_sizes_path, assembled_contig, assembled_scaffold,
-                      bowtie_sam, contig_stats, read2contig, int(memory))
+        min_contig_length = int(self.additional_attributes.get('min_contig_length', 0))
+        self.assemble(input_fasta, input_fasta2, bowtie_fasta, duplicate_cluster_sizes_path,
+                      assembled_contig, assembled_contig_all, assembled_scaffold,
+                      bowtie_sam, contig_stats, read2contig, int(memory), min_contig_length)
 
     @staticmethod
     def assemble(input_fasta,
@@ -76,11 +79,13 @@ class PipelineStepRunAssembly(PipelineStep):
                  bowtie_fasta,  # fasta file for running bowtie against contigs
                  duplicate_cluster_sizes_path,
                  assembled_contig,
+                 assembled_contig_all,
                  assembled_scaffold,
                  bowtie_sam,
                  contig_stats,
                  read2contig,
-                 memory=100):
+                 memory=100,
+                 min_contig_length=0):
         basedir = os.path.dirname(assembled_contig)
         assembled_dir = os.path.join(basedir, 'spades')
         command.make_dirs(assembled_dir)
@@ -124,14 +129,25 @@ class PipelineStepRunAssembly(PipelineStep):
                         ]
                     )
                 )
-            command.move_file(assembled_contig_tmp, assembled_contig)
+            command.move_file(assembled_contig_tmp, assembled_contig_all)
             command.move_file(assembled_scaffold_tmp, assembled_scaffold)
+
+            if min_contig_length:
+                # apply contig length filter
+                with open(assembled_contig, "w") as outfile:
+                    for record in fasta.iterator(assembled_contig_all):
+                        if len(record.sequence) >= min_contig_length:
+                            print(record.header, file=outfile)
+                            print(record.sequence, file=outfile)
+            else:
+                command.copy_file(assembled_contig_all, assembled_contig)
 
             PipelineStepRunAssembly.generate_read_to_contig_mapping(assembled_contig, bowtie_fasta,
                                                                     read2contig, duplicate_cluster_sizes_path, bowtie_sam, contig_stats)
         except:
             # Assembly failed. create dummy output files
             command.write_text_to_file(';ASSEMBLY FAILED', assembled_contig)
+            command.write_text_to_file(';ASSEMBLY FAILED', assembled_contig_all)
             command.write_text_to_file(';ASSEMBLY FAILED', assembled_scaffold)
             command.write_text_to_file('@NO INFO', bowtie_sam)
             command.write_text_to_file('{}', contig_stats)

--- a/short-read-mngs/idseq-dag/idseq_dag/steps/run_assembly.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/steps/run_assembly.py
@@ -3,10 +3,10 @@ import json
 import os
 import traceback
 from collections import defaultdict
+from Bio import SeqIO
 from idseq_dag.engine.pipeline_step import PipelineStep
 import idseq_dag.util.command as command
 import idseq_dag.util.command_patterns as command_patterns
-import idseq_dag.util.fasta as fasta
 
 from idseq_dag.util.m8 import MIN_CONTIG_SIZE
 from idseq_dag.util.count import get_read_cluster_size, load_duplicate_cluster_sizes, READ_COUNTING_MODE, ReadCountingMode
@@ -134,11 +134,12 @@ class PipelineStepRunAssembly(PipelineStep):
 
             if min_contig_length:
                 # apply contig length filter
-                with open(assembled_contig, "w") as outfile:
-                    for record in fasta.iterator(assembled_contig_all):
-                        if len(record.sequence) >= min_contig_length:
-                            print(record.header, file=outfile)
-                            print(record.sequence, file=outfile)
+                SeqIO.write(
+                    (r for r in SeqIO.parse(assembled_contig_all, "fasta")
+                        if len(r.seq) >= min_contig_length),
+                    assembled_contig,
+                    "fasta",
+                )
             else:
                 command.copy_file(assembled_contig_all, assembled_contig)
 

--- a/short-read-mngs/idseq-dag/idseq_dag/util/fasta.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/util/fasta.py
@@ -13,23 +13,19 @@ class Read(NamedTuple):
 
 def iterator(fasta_file: str) -> Iterator[Read]:
     """Iterate through fasta_file, yielding one Read tuple at a time."""
+    # TODO: Support full fasta format, where sequences may be split over multiple lines.
+    # Perf: 47 million (unpaired) reads per minute on a high end 2018 laptop.
     with open(fasta_file, 'r', encoding='utf-8') as f:
-        header = None
-        sequence_wip = []
         while True:
-            line = f.readline().rstrip()
-            if not line:
+            header = f.readline().rstrip()
+            sequence = f.readline().rstrip()
+            if not header or not sequence:
                 break
-            if line[0] == '>':
-                if header:
-                    yield Read(header, ("".join(sequence_wip) if len(sequence_wip) != 1 else sequence_wip[0]))
-                header = line
-                sequence_wip.clear()
-            else:
-                assert header, "FASTA file doesn't begin with header"
-                sequence_wip.append(line)
-        if header:
-            yield Read(header, "".join(sequence_wip))
+            # the performance penalty for these asserts is only 8 percent
+            assert header[0] == '>'
+            assert sequence[0] != '>'
+            # the performance penalty for constructing a Read tuple is 40 percent
+            yield Read(header, sequence)
 
 def synchronized_iterator(fasta_files: List[str]) -> Iterator[Tuple[Read, ...]]:
     """Iterate through one or more fasta files in lockstep, yielding tuples of

--- a/short-read-mngs/idseq-dag/setup.py
+++ b/short-read-mngs/idseq-dag/setup.py
@@ -10,7 +10,7 @@ setup(name='idseq_dag',
       license='MIT',
       packages=find_packages(exclude=["tests.*", "tests"]),
       package_data={'idseq_dag': ['scripts/fastq-fasta-line-validation.awk']},
-      install_requires=["pytz", "boto3"],
+      install_requires=["pytz", "boto3", "biopython"],
       tests_require=["coverage", "flake8", "wheel"],
       dependency_links=[],
       entry_points={

--- a/short-read-mngs/postprocess.wdl
+++ b/short-read-mngs/postprocess.wdl
@@ -6,6 +6,7 @@ task RunAssembly {
     String s3_wd_uri
     Array[File] host_filter_out_gsnap_filter_fa
     File duplicate_cluster_sizes_tsv
+    Int min_contig_length = 100
   }
   command<<<
   set -euxo pipefail
@@ -14,14 +15,15 @@ task RunAssembly {
     --step-class PipelineStepRunAssembly \
     --step-name assembly_out \
     --input-files '[["~{sep='","' host_filter_out_gsnap_filter_fa}"], ["~{duplicate_cluster_sizes_tsv}"]]' \
-    --output-files '["assembly/contigs.fasta", "assembly/scaffolds.fasta", "assembly/read-contig.sam", "assembly/contig_stats.json"]' \
+    --output-files '["assembly/contigs.fasta", "assembly/contigs_all.fasta", "assembly/scaffolds.fasta", "assembly/read-contig.sam", "assembly/contig_stats.json"]' \
     --output-dir-s3 '~{s3_wd_uri}' \
     --additional-files '{}' \
-    --additional-attributes '{"memory": 200}'
+    --additional-attributes '{"memory": 200, "min_contig_length": ~{min_contig_length}}'
   >>>
   output {
     String step_description_md = read_string("assembly_out.description.md")
     File assembly_contigs_fasta = "assembly/contigs.fasta"
+    File assembly_contigs_all_fasta = "assembly/contigs_all.fasta"
     File assembly_scaffolds_fasta = "assembly/scaffolds.fasta"
     File assembly_read_contig_sam = "assembly/read-contig.sam"
     File assembly_contig_stats_json = "assembly/contig_stats.json"
@@ -659,6 +661,7 @@ workflow idseq_postprocess {
 
   output {
     File assembly_out_assembly_contigs_fasta = RunAssembly.assembly_contigs_fasta
+    File assembly_out_assembly_contigs_all_fasta = RunAssembly.assembly_contigs_all_fasta
     File assembly_out_assembly_scaffolds_fasta = RunAssembly.assembly_scaffolds_fasta
     File assembly_out_assembly_read_contig_sam = RunAssembly.assembly_read_contig_sam
     File assembly_out_assembly_contig_stats_json = RunAssembly.assembly_contig_stats_json

--- a/short-read-mngs/postprocess.wdl
+++ b/short-read-mngs/postprocess.wdl
@@ -6,7 +6,7 @@ task RunAssembly {
     String s3_wd_uri
     Array[File] host_filter_out_gsnap_filter_fa
     File duplicate_cluster_sizes_tsv
-    Int min_contig_length = 100
+    Int min_contig_length
   }
   command<<<
   set -euxo pipefail
@@ -481,6 +481,7 @@ workflow idseq_postprocess {
     File deuterostome_db = "s3://idseq-public-references/taxonomy/2020-04-20/deuterostome_taxids.txt"
     Boolean use_deuterostome_filter = true
     Boolean use_taxon_whitelist = false
+    Int min_contig_length = 100
   }
 
   call RunAssembly {
@@ -488,7 +489,8 @@ workflow idseq_postprocess {
       docker_image_id = docker_image_id,
       s3_wd_uri = s3_wd_uri,
       host_filter_out_gsnap_filter_fa = select_all([host_filter_out_gsnap_filter_1_fa, host_filter_out_gsnap_filter_2_fa, host_filter_out_gsnap_filter_merged_fa]),
-      duplicate_cluster_sizes_tsv = duplicate_cluster_sizes_tsv
+      duplicate_cluster_sizes_tsv = duplicate_cluster_sizes_tsv,
+      min_contig_length = min_contig_length
   }
 
   call GenerateCoverageStats {

--- a/short-read-mngs/test/README.md
+++ b/short-read-mngs/test/README.md
@@ -26,5 +26,5 @@ Then, build the docker image from the current code revision and start the tests:
 ```bash
 cd idseq-workflows
 docker build -t idseq-short-read-mngs short-read-mngs
-make test-short-read-mngs
+DOCKER_IMAGE_ID=idseq-short-read-mngs make test-short-read-mngs
 ```

--- a/short-read-mngs/test/postprocess/test_RunAssembly.py
+++ b/short-read-mngs/test/postprocess/test_RunAssembly.py
@@ -13,7 +13,7 @@ def test_RunAssembly_defaults(util, short_read_mngs_bench3_viral_outputs):
     assembly_contigs_all_fasta = short_read_mngs_bench3_viral_outputs["outputs"][
         "idseq_short_read_mngs.postprocess.assembly_out_assembly_contigs_all_fasta"
     ]
-    assert os.path.getsize(assembly_contigs_fasta) == os.path.getsize(assembly_contigs_all_fasta)
+    assert count_fasta(assembly_contigs_fasta) == count_fasta(assembly_contigs_all_fasta)
 
 
 def test_RunAssembly_filtered(util, short_read_mngs_bench3_viral_outputs):

--- a/short-read-mngs/test/postprocess/test_RunAssembly.py
+++ b/short-read-mngs/test/postprocess/test_RunAssembly.py
@@ -1,0 +1,68 @@
+import os
+import json
+import csv
+import tempfile
+
+
+def test_RunAssembly_defaults(util, short_read_mngs_bench3_viral_outputs):
+    """
+    On default settings, the assembly_out_contigs_fasta and assembly_out_contigs_all_fasta files
+    should be identicaly (because all contigs pass the default min_contig_length filter)
+    """
+    task_name = "RunAlignment_gsnap_out"
+    assembly_contigs_fasta = short_read_mngs_bench3_viral_outputs["outputs"][
+        "idseq_short_read_mngs.postprocess.assembly_out_assembly_contigs_fasta"
+    ]
+    assembly_contigs_all_fasta = short_read_mngs_bench3_viral_outputs["outputs"][
+        "idseq_short_read_mngs.postprocess.assembly_out_assembly_contigs_all_fasta"
+    ]
+    assert os.path.getsize(assembly_contigs_fasta) == os.path.getsize(assembly_contigs_all_fasta)
+
+
+def test_RunAssembly_filtered(util, short_read_mngs_bench3_viral_outputs):
+    """
+    Re-run the assembly task with a higher min_contig_length and observe that contigs are removed.
+    """
+    # load the task's inputs from the end-to-end workflow test
+    task_name = "RunAssembly"
+    inputs, _ = util.miniwdl_inputs_outputs(
+        os.path.join(
+            short_read_mngs_bench3_viral_outputs["dir"],
+            "call-postprocess",
+            f"call-{task_name}",
+        )
+    )
+
+    # override min_contig_length
+    inputs["min_contig_length"] = 150
+
+    # rerun
+    outp = util.miniwdl_run(
+        util.repo_dir() / "short-read-mngs/postprocess.wdl",
+        "--task",
+        task_name,
+        "-i",
+        json.dumps(inputs),
+    )
+
+    # count fasta
+    assembly_contigs_fasta = os.path.join(
+        outp["dir"], outp["outputs"][f"{task_name}.assembly_contigs_fasta"]
+    )
+    assembly_contigs_all_fasta = os.path.join(
+        outp["dir"], outp["outputs"][f"{task_name}.assembly_contigs_all_fasta"]
+    )
+    assert count_fasta(assembly_contigs_fasta) and count_fasta(
+        assembly_contigs_fasta
+    ) < count_fasta(assembly_contigs_all_fasta)
+
+
+def count_fasta(fn):
+    ans = 0
+    with open(fn) as infile:
+        while True:
+            line = infile.readline()
+            if not line:
+                return ans
+            if line[0] == ">":
+                ans += 1

--- a/short-read-mngs/test/postprocess/test_RunAssembly.py
+++ b/short-read-mngs/test/postprocess/test_RunAssembly.py
@@ -13,7 +13,10 @@ def test_RunAssembly_defaults(util, short_read_mngs_bench3_viral_outputs):
     assembly_contigs_all_fasta = short_read_mngs_bench3_viral_outputs["outputs"][
         "idseq_short_read_mngs.postprocess.assembly_out_assembly_contigs_all_fasta"
     ]
-    assert count_fasta(assembly_contigs_fasta) == count_fasta(assembly_contigs_all_fasta)
+    assert fasta_headers(assembly_contigs_fasta) == fasta_headers(assembly_contigs_all_fasta)
+    # quick&dirty: the contents should be identical modulo newlines
+    with open(assembly_contigs_fasta) as in1, open(assembly_contigs_all_fasta) as in2:
+        assert in1.read().replace("\n", "") == in2.read().replace("\n", "")
 
 
 def test_RunAssembly_filtered(util, short_read_mngs_bench3_viral_outputs):
@@ -49,17 +52,17 @@ def test_RunAssembly_filtered(util, short_read_mngs_bench3_viral_outputs):
     assembly_contigs_all_fasta = os.path.join(
         outp["dir"], outp["outputs"][f"{task_name}.assembly_contigs_all_fasta"]
     )
-    assert count_fasta(assembly_contigs_fasta) and count_fasta(
-        assembly_contigs_fasta
-    ) < count_fasta(assembly_contigs_all_fasta)
+    contigs_headers = fasta_headers(assembly_contigs_fasta)
+    contigs_all_headers = fasta_headers(assembly_contigs_all_fasta)
+    assert contigs_headers and (set(contigs_all_headers) - set(contigs_headers))
 
 
-def count_fasta(fn):
-    ans = 0
+def fasta_headers(fn):
+    ans = []
     with open(fn) as infile:
         while True:
             line = infile.readline()
             if not line:
                 return ans
             if line[0] == ">":
-                ans += 1
+                ans.append(line)

--- a/short-read-mngs/test/postprocess/test_RunAssembly.py
+++ b/short-read-mngs/test/postprocess/test_RunAssembly.py
@@ -1,7 +1,5 @@
 import os
 import json
-import csv
-import tempfile
 
 
 def test_RunAssembly_defaults(util, short_read_mngs_bench3_viral_outputs):
@@ -9,7 +7,6 @@ def test_RunAssembly_defaults(util, short_read_mngs_bench3_viral_outputs):
     On default settings, the assembly_out_contigs_fasta and assembly_out_contigs_all_fasta files
     should be identicaly (because all contigs pass the default min_contig_length filter)
     """
-    task_name = "RunAlignment_gsnap_out"
     assembly_contigs_fasta = short_read_mngs_bench3_viral_outputs["outputs"][
         "idseq_short_read_mngs.postprocess.assembly_out_assembly_contigs_fasta"
     ]

--- a/short-read-mngs/test/postprocess/test_RunAssembly.py
+++ b/short-read-mngs/test/postprocess/test_RunAssembly.py
@@ -5,7 +5,7 @@ import json
 def test_RunAssembly_defaults(util, short_read_mngs_bench3_viral_outputs):
     """
     On default settings, the assembly_out_contigs_fasta and assembly_out_contigs_all_fasta files
-    should be identicaly (because all contigs pass the default min_contig_length filter)
+    should be identical (because all contigs pass the default min_contig_length filter)
     """
     assembly_contigs_fasta = short_read_mngs_bench3_viral_outputs["outputs"][
         "idseq_short_read_mngs.postprocess.assembly_out_assembly_contigs_fasta"


### PR DESCRIPTION
Apply a 100-nucleotide length filter to the contigs as they emerge from SPAdes, to reduce the burden on subsequent steps like BlastContigs. Shorter contigs can make up a majority of SPAdes output currently (sample-dependent), yet seem of minimal value considering they're shorter than the input reads.

The downfiltered contigs are used for all subsequent steps (including the Bowtie2 realignment of reads to contigs immediately following SPAdes). The original set is copied into a new workflow output, `assembly_out_assembly_contigs_all_fasta`, which remains unused.