### PR TITLE
fix bug with NA values in ska.distances.tsv and add known user error for divergent samples

### DIFF
--- a/phylotree-ng/python_steps/compute_clusters.py
+++ b/phylotree-ng/python_steps/compute_clusters.py
@@ -26,6 +26,7 @@ def main(ska_distances: str, trim_height: float, samples: Iterable[Sample], outp
     # we may need to use a regex separator
     df = pd.read_csv(ska_distances, sep='\t')
     df.reset_index(drop=True, inplace=True)
+    df.fillna(1, inplace=True) # fill NA values for SNP and Mash-like Distance with 1 (maximum dist)
 
     # long dataframe to wide
     df2 = df.pivot_table(index=['Sample 1'], columns='Sample 2', values='Mash-like distance')

--- a/phylotree-ng/python_steps/compute_clusters.py
+++ b/phylotree-ng/python_steps/compute_clusters.py
@@ -26,7 +26,7 @@ def main(ska_distances: str, trim_height: float, samples: Iterable[Sample], outp
     # we may need to use a regex separator
     df = pd.read_csv(ska_distances, sep='\t')
     df.reset_index(drop=True, inplace=True)
-    df.fillna(1, inplace=True) # fill NA values for SNP and Mash-like Distance with 1 (maximum dist)
+    df.fillna(1, inplace=True)  # fill NA values for SNP and Mash-like Distance with 1 (maximum dist)
 
     # long dataframe to wide
     df2 = df.pivot_table(index=['Sample 1'], columns='Sample 2', values='Mash-like distance')

--- a/phylotree-ng/run.wdl
+++ b/phylotree-ng/run.wdl
@@ -232,6 +232,14 @@ task GenerateClusterPhylos {
     ska merge -o ska.merged ska_hashes/*.skf
     ska align -p "~{ska_align_p}" -o ska -v ska.merged.skf
     mv ska_variants.aln ska.variants.aln
+
+    num_zero_variant_samples=`grep -c "^$" ska.variants.aln`
+    if [[ $num_zero_variant_samples -gt 0 ]]; then
+        export error=TooDivergentError cause="Sequences are too divergent to create a single phylo tree"
+        jq -nc ".wdl_error_message=true | .error=env.error | .cause=env.cause" > /dev/stderr
+        exit 4
+    fi
+
     iqtree -s ska.variants.aln
     mv ska.variants.aln.treefile phylotree.nwk
     >>>


### PR DESCRIPTION
There are cases where NA values will appear in the ska.distances.tsv file for samples with no overlapping kmers. We were filling `na` values with zeroes at a later step in the `ComputeClusters` script, but this gives the false appearance that these samples are extremely similar. This update applies `fillna = 1` earlier in the parsing of the `ska.distances.tsv` file so that the samples with NA values are maximally divergent in the resulting heatmap.

Additionally, cases where NA values appear in the `ska.distances.tsv` file may result in the case where there are no variants from which to construct the tree. This causes an error due to invalid inputs to iqtree (i.e. a malformed .fasta file). For example:
```
>seq1

>seq2

>seq3

```

This PR also adds functionality to catch such errors under the class of `TooDivergentError`.

This was tested on a sample set that generated NA values in the `ska.distances.tsv` file.