### PR TITLE
re-enable threading in bowtie2

### DIFF
--- a/short-read-mngs/idseq-dag/idseq_dag/steps/run_bowtie2.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/steps/run_bowtie2.py
@@ -65,12 +65,13 @@ class PipelineStepRunBowtie2(PipelineCountingStep):
             '--very-sensitive-local', '-S', output_sam_file
         ]
 
-        # FIXME: https://jira.czi.team/browse/IDSEQ-2738
-        #  We want to move towards a general randomness solution in which
-        #  all randomness is seeded based on the content of the original input.
-        #  This is currently introducing non-determinism and hard coding
-        #  an arbitrary seed here shouldn't impact correctness.
-        bowtie2_params.extend(['--seed', '4'])  # chosen by fair dice role, guaranteed to be random
+        # --seed cannot be used with -p multithreading
+        # We have observed the lack of multithreading resulting in
+        # severe performance degradation in some cases. So for the
+        # time being multithreading is being chosen over determinism.
+        # To seed bowtie2 do something similar to:
+        # bowtie2_params.extend(['--seed', '4'])
+        bowtie2_params.extend(['-p', str(multiprocessing.cpu_count())])
 
         if len(input_fas) == 2:
             bowtie2_params.extend(['-1', input_fas[0], '-2', input_fas[1]])

--- a/short-read-mngs/test/test_short_read_mngs.py
+++ b/short-read-mngs/test/test_short_read_mngs.py
@@ -29,7 +29,7 @@ def test_bench3_viral(short_read_mngs_bench3_viral_outputs):
         taxon_counts = json.load(infile)["pipeline_output"]["taxon_counts_attributes"]
 
     taxa = set(entry["tax_id"] for entry in taxon_counts)
-    assert len(taxa) == 149
+    assert abs(len(taxa) - 149) < 5
 
     for filename in outp["outputs"]:
         if filename.endswith(".fasta"):


### PR DESCRIPTION
While doing some stuff for on call I discovered and diagnosed an issue with our usage of bowtie2. bowtie2 now sometimes times out after 5 hours. I re-ran a sample from two years ago and though nearly everything was identical the former took well under an hour and the latter took over five. After analyzing the diff I found that as part of of my effort to make the pipeline results deterministic I added the `--seed` parameter to bowtie2. This `--seed` parameter is not compatible with multithreading so I disabled multithreading. bowtie2 isn't super time consuming and this ended up being mostly fine but it seems we have observed some performance issues with this approach. Though determinism is important I think our users are far more interested in their samples running in the first place than determinism (which almost none of them are really aware of). For now I am going to switch back and leave a comment. Determinism with multi-threading inherently leads to more complexity and overhead. We may need to do some experiments to see if we can get determinism in a more scalable way.

Here is the ticket about this that we closed: https://app.clubhouse.io/idseq/story/11242/fix-bowtie-timeout-after-10-hours-on-150m-total-read-samples