### PR TITLE
Push docker images to ghcr.io

### DIFF
--- a/.github/workflows/short-read-mngs-viral-benchmarks.yml
+++ b/.github/workflows/short-read-mngs-viral-benchmarks.yml
@@ -40,10 +40,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: docker build
         run: |
-            echo "${{ secrets.GITHUB_TOKEN }}" \
-                | docker login docker.pkg.github.com --username $(dirname $GITHUB_REPOSITORY) --password-stdin
             IMAGE_NAME=idseq-short-read-mngs-public
-            IMAGE_URI="docker.pkg.github.com/${GITHUB_REPOSITORY}/${IMAGE_NAME}"
+            IMAGE_URI="ghcr.io/${GITHUB_REPOSITORY}/${IMAGE_NAME}"
             CACHE_FROM=""; docker pull "$IMAGE_URI" && CACHE_FROM="--cache-from $IMAGE_URI"
             docker build short-read-mngs --tag idseq-short-read-mngs $CACHE_FROM \
                 || docker build short-read-mngs --tag idseq-short-read-mngs

--- a/.github/workflows/wdl-ci.yml
+++ b/.github/workflows/wdl-ci.yml
@@ -59,15 +59,17 @@ jobs:
         workflow_dir: ${{fromJson(needs['list-workflow-dirs'].outputs.matrix)}}
     steps:
       - uses: actions/checkout@v2
-      - name: docker login
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" \
-            | docker login docker.pkg.github.com --username $(dirname $GITHUB_REPOSITORY) --password-stdin
-      - name: docker build
+      - name: docker login ghcr.io
+        uses: docker/login-action@v1
+        with:
+            registry: ghcr.io
+            username: ${{ github.repository_owner }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+      - name: docker build + push to ghcr.io
         run: |
           TAG=$(git describe --long --tags --always --dirty)
           IMAGE_NAME=idseq-${{ matrix.workflow_dir }}-public
-          IMAGE_URI="docker.pkg.github.com/${GITHUB_REPOSITORY}/${IMAGE_NAME}"
+          IMAGE_URI="ghcr.io/${GITHUB_REPOSITORY}/${IMAGE_NAME}"
 
           CACHE_FROM=""; docker pull "$IMAGE_URI" && CACHE_FROM="--cache-from $IMAGE_URI"
           docker build "${{ matrix.workflow_dir }}" --tag "${IMAGE_URI}:${TAG}" $CACHE_FROM \
@@ -105,3 +107,14 @@ jobs:
           export DOCKER_IMAGE_ID="${IMAGE_URI}:${TAG}"
 
           make test-${{ matrix.workflow_dir }}
+      - name: docker push to docker.pkg.github.com (legacy)
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | docker login docker.pkg.github.com --username $(dirname $GITHUB_REPOSITORY) --password-stdin
+          LEGACY_IMAGE_URI=$(sed s/ghcr.io/docker.pkg.github.com/ <<< "$IMAGE_URI")
+          docker tag "${IMAGE_URI}:${TAG}" "${LEGACY_IMAGE_URI}:${TAG}"
+          docker push "${LEGACY_IMAGE_URI}:${TAG}"
+          if [[ ${GITHUB_REF##*/} == "main" ]]; then
+            docker tag "${IMAGE_URI}:${TAG}" "${LEGACY_IMAGE_URI}:latest"
+            docker push "${LEGACY_IMAGE_URI}:latest"
+          fi

--- a/consensus-genome/Dockerfile
+++ b/consensus-genome/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
-LABEL maintainer="IDseq Team idseq-tech@chanzuckerberg.com"
+LABEL maintainer="IDseq Team <idseq-tech@chanzuckerberg.com>"
 LABEL description = "Image for consensus genome by metagenomic sequencing with spiked primer enrichment or amplicon sequencing"
 
 RUN sed -i s/archive.ubuntu.com/us-west-2.ec2.archive.ubuntu.com/ /etc/apt/sources.list; \

--- a/short-read-mngs/Dockerfile
+++ b/short-read-mngs/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 ARG DEBIAN_FRONTEND=noninteractive
 ARG MINIWDL_VERSION=1.1.5
 
-LABEL maintainer="IDseq Team idseq-tech@chanzuckerberg.com"
+LABEL maintainer="IDseq Team <idseq-tech@chanzuckerberg.com>"
 
 RUN sed -i s/archive.ubuntu.com/us-west-2.ec2.archive.ubuntu.com/ /etc/apt/sources.list; \
         echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/98idseq; \


### PR DESCRIPTION
Updates CI workflows to push docker images to the new GitHub Container Registry (ghcr.io), which makes them available to the public without any login. This will make it easier for others to reuse our workflows because they can get the docker images without either (i) logging into the registry or (ii) building them locally.

For now we'll *also* continue pushing the images to the older docker.pkg.github.com in case something else assumes it's there. (IDseq itself distributes images internally using the AWS docker registry, so shouldn't be affected)