### PR TITLE
[CH-143966] Adjust phylo heatmap styling

### DIFF
--- a/phylotree-ng/Dockerfile
+++ b/phylotree-ng/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get -qq update && apt-get -qq -y install \
     python3-dateutil \
     iqtree \
     build-essential \
+    fonts-open-sans \
     && locale-gen en_US.UTF-8
 
 RUN curl -L https://github.com/simonrharris/SKA/archive/refs/tags/v1.0.tar.gz | tar -xvz && \


### PR DESCRIPTION
- Ticket: https://app.clubhouse.io/idseq/story/143966/adjust-the-phylo-pipeline-heatmap-image-output-for-visual-tweaks

# Description
- Visual adjustments to make the phylo heatmap look closer to the other heatmap.
- Main gap is that I couldn't find a way to move the dendrograms over to the right/bottom.

# Notes
Looks like this:

![clustermap](https://user-images.githubusercontent.com/5652739/128243642-188f0c3f-fbfa-464e-b2ce-260dd23fe30e.png)

# Tests
- Tested locally by running this command with some samples from staging and opening the heatmap: `miniwdl run --verbose run.wdl docker_image_id=phylotree-ng cut_height=.14 ska_align_p=.9 reference_taxon_id=333750 superkingdom_name=viruses --input test/local_test.yml`