### PR TITLE
Tweak phylo heatmap style

### DIFF
--- a/phylotree-ng/python_steps/compute_clusters.py
+++ b/phylotree-ng/python_steps/compute_clusters.py
@@ -72,7 +72,7 @@ def main(ska_distances: str, trim_height: float, samples: Iterable[Sample], outp
     rcParams['font.family'] = 'sans-serif'
     rcParams['font.sans-serif'] = ['Open Sans']
     # 1.0 is baseline font size
-    sns.set(font_scale = 1.15)
+    sns.set(font_scale=1.15)
 
     chart = sns.clustermap(
         df3,
@@ -90,7 +90,7 @@ def main(ska_distances: str, trim_height: float, samples: Iterable[Sample], outp
         linewidth=5,
         row_linkage=Z,
         # Set dendogram color.
-        tree_kws={'colors':"#767676"},
+        tree_kws={'colors': "#767676"},
         vmax=0.15,
         vmin=0,
     )

--- a/phylotree-ng/python_steps/compute_clusters.py
+++ b/phylotree-ng/python_steps/compute_clusters.py
@@ -71,6 +71,8 @@ def main(ska_distances: str, trim_height: float, samples: Iterable[Sample], outp
     # Use Open Sans for the labels
     rcParams['font.family'] = 'sans-serif'
     rcParams['font.sans-serif'] = ['Open Sans']
+    # 1.0 is baseline font size
+    sns.set(font_scale = 1.15)
 
     chart = sns.clustermap(
         df3,
@@ -87,6 +89,8 @@ def main(ska_distances: str, trim_height: float, samples: Iterable[Sample], outp
         linecolor='w',
         linewidth=5,
         row_linkage=Z,
+        # Set dendogram color.
+        tree_kws={'colors':"#767676"},
         vmax=0.15,
         vmin=0,
     )


### PR DESCRIPTION
# Description
- From @happyimadesignr : Makes the font size a little bigger + 767676 for the dendrogram.

# Notes

![clustermap](https://user-images.githubusercontent.com/5652739/128581247-e6f05232-0369-4903-97fa-6da902e014e8.png)

# Tests
- Ran it locally.