### PR TITLE
fix issue with clusters in phylotree

### DIFF
--- a/phylotree-ng/run.wdl
+++ b/phylotree-ng/run.wdl
@@ -231,6 +231,9 @@ task GenerateClusterPhylos {
     }
 
     command <<<
+    # -e omitted because iqtree can exit with a non-zero exit code despite
+    #   producing valid output
+    set -uxo pipefail
     tar -xzvf "~{clusters_directory}"
     tar -xzvf "~{ska_hashes}"
 

--- a/phylotree-ng/run.wdl
+++ b/phylotree-ng/run.wdl
@@ -235,14 +235,12 @@ task GenerateClusterPhylos {
     tar -xzvf "~{clusters_directory}"
     tar -xzvf "~{ska_hashes}"
 
-    CLUSTER_FILE=$(ls cluster_files | head -n 1)
-    mkdir cluster
-    for hash in `cat cluster_files/$CLUSTER_FILE`
-    do
-        cp ska_hashes/$hash.skf cluster
-    done
+    if [[ $(ls cluster_files | wc -l) -gt 1 ]]; then
+      # If we have more than one cluster then the samples are too
+      #   divergent and we should not generate a tree
+      exit 0
+    fi
 
-    mkdir ska_outputs
     ska distance -o ska cluster/*.skf
     ska merge -o ska.merged cluster/*.skf
     ska align -p "~{ska_align_p}" -o ska -v ska.merged.skf

--- a/phylotree-ng/run.wdl
+++ b/phylotree-ng/run.wdl
@@ -234,14 +234,14 @@ task GenerateClusterPhylos {
 
     CLUSTER_FILE=$(ls cluster_files | head -n 1)
     mkdir cluster
-    for hash in `cat $CLUSTER_FILE`
+    for hash in `cat cluster_files/$CLUSTER_FILE`
     do
         cp ska_hashes/$hash.skf cluster
     done
 
     mkdir ska_outputs
-    ska distance -o ska ska_hashes/*.skf
-    ska merge -o ska.merged ska_hashes/*.skf
+    ska distance -o ska cluster/*.skf
+    ska merge -o ska.merged cluster/*.skf
     ska align -p "~{ska_align_p}" -o ska -v ska.merged.skf
     mv ska_variants.aln ska.variants.aln
 

--- a/phylotree-ng/run.wdl
+++ b/phylotree-ng/run.wdl
@@ -241,8 +241,8 @@ task GenerateClusterPhylos {
       exit 0
     fi
 
-    ska distance -o ska cluster/*.skf
-    ska merge -o ska.merged cluster/*.skf
+    ska distance -o ska ska_hashes/*.skf
+    ska merge -o ska.merged ska_hashes/*.skf
     ska align -p "~{ska_align_p}" -o ska -v ska.merged.skf
     mv ska_variants.aln ska.variants.aln
 

--- a/phylotree-ng/run.wdl
+++ b/phylotree-ng/run.wdl
@@ -231,7 +231,6 @@ task GenerateClusterPhylos {
     }
 
     command <<<
-    set -euxo pipefail
     tar -xzvf "~{clusters_directory}"
     tar -xzvf "~{ska_hashes}"
 
@@ -241,7 +240,6 @@ task GenerateClusterPhylos {
       exit 0
     fi
 
-    mkdir ska_outputs
     ska distance -o ska ska_hashes/*.skf
     ska merge -o ska.merged ska_hashes/*.skf
     ska align -p "~{ska_align_p}" -o ska -v ska.merged.skf

--- a/phylotree-ng/run.wdl
+++ b/phylotree-ng/run.wdl
@@ -107,6 +107,7 @@ task GetReferenceAccessionFastas {
     }
 
     command <<<
+    set -euxo pipefail
         for accession_id in ~{sep=' ' accession_ids}; do
             taxoniq get-from-s3 --accession-id $accession_id > $accession_id.fasta
             if [[ $? == 4 ]]; then
@@ -163,6 +164,7 @@ task RunSKA {
     }
 
     command <<<
+    set -euxo pipefail
     k=18
     if [[ "~{superkingdom_name}" == viruses ]]; then
         k=12
@@ -199,7 +201,7 @@ task ComputeClusters {
     }
 
     command <<<
-    set -e
+    set -euxo pipefail
     mkdir cluster_files
     python3 /bin/compute_clusters.py \
         --ska-distances ~{ska_distances} \
@@ -229,6 +231,7 @@ task GenerateClusterPhylos {
     }
 
     command <<<
+    set -euxo pipefail
     tar -xzvf "~{clusters_directory}"
     tar -xzvf "~{ska_hashes}"
 

--- a/phylotree-ng/run.wdl
+++ b/phylotree-ng/run.wdl
@@ -241,6 +241,7 @@ task GenerateClusterPhylos {
       exit 0
     fi
 
+    mkdir ska_outputs
     ska distance -o ska ska_hashes/*.skf
     ska merge -o ska.merged ska_hashes/*.skf
     ska align -p "~{ska_align_p}" -o ska -v ska.merged.skf


### PR DESCRIPTION
😲 not sure how I missed this...

### What happened?

This is kind of a confluence of errors that combined to make them hard to notice.

First, I want to get the first cluster file which contains a file name per line. For each of those file names I want to move them into a new directory that will only hold the files that are in the cluster. Here is where I made my first mistake. I listed `cluster_files` to get the first file but I `cat`ed the filename without the directory name:

```bash
CLUSTER_FILE=$(ls cluster_files | head -n 1)
mkdir cluster
for hash in `cat $CLUSTER_FILE`
do
```

OK so this `cat` failed every time. Why didn't we notice? Well I forgot to add `set -euxo pipefail` so the script just continues on.

But the `cluster` directory is empty, how can we use it? It turns out we don't... I was just using the entire `ska_hashes` directory:

```bash
ska distance -o ska ska_hashes/*.skf
ska merge -o ska.merged ska_hashes/*.skf
```

This uses the hashes directory that contains all of the hashes from all of the clusters. Since we are not producing a tree if there is more than one cluster this is actually fine and the for loop is a carryover from when we were producing trees for each cluster. I can remove it completely and just use `ska_hashes` directly.

Also, we made too many clusters not an error. I removed the error version in the previous distances but I need to add the cluster check in this step. The check must occur in the same step now because the previous step will succeed and produce output even if there is more than one cluster.

So I did all this and it failed. It turns out `iqtree` is exiting with a non-zero exit code even though the test is asserting it produced a valid tree. So I had to remove `-e` from the settings.