### PR TITLE
force path to genome to standard name

### DIFF
--- a/short-read-mngs/host_filter.wdl
+++ b/short-read-mngs/host_filter.wdl
@@ -55,7 +55,8 @@ task RunStar {
     f.write(description)
   CODE
 
-  tar -xf "~{star_genome}"
+  mkdir "STAR_genome"
+  tar xf "~{star_genome}" -C "STAR_genome" --strip-components 1
   # Set Parameters
   SAMMODE="None"
   SAMTYPE="None"


### PR DESCRIPTION
I had incorrectly assumed that the standard folder structure for the STAR genomes was "STAR_genome/part-0", when it was really "[hostname]_STAR_genome/part-0/" for everything other than the test STAR genome. 

This fix forces the directory to be "STAR_genome/part-0".  