### PR TITLE
fix bug with reading back idseq clusters

### DIFF
--- a/short-read-mngs/idseq-dag/idseq_dag/util/idseq_dedup_clusters.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/util/idseq_dedup_clusters.py
@@ -12,8 +12,12 @@ def parse_clusters_file(
 ) -> Dict[str, Optional[List]]:
     clusters_dict = {}
     with open(idseq_dedup_clusters_path) as f:
-        for row in DictReader(f, skipinitialspace=True):
+        for row in DictReader(f):
             r_read_id, read_id = row["representative read id"], row["read id"]
+            if r_read_id[0] == "'":
+                r_read_id = r_read_id[1:]
+            if read_id[0] == "'":
+                read_id = read_id[1:]
             if r_read_id not in clusters_dict:
                 clusters_dict[r_read_id] = [1]
             else:


### PR DESCRIPTION
If a cell starts with `'` we know it was added. If a cell started with `'` naturally it would have had a second `'` prepended so this logic should always produce the identical input. 