### PR TITLE
ignore divergent iqtree error

### DIFF
--- a/phylotree-ng/run.wdl
+++ b/phylotree-ng/run.wdl
@@ -256,8 +256,13 @@ task GenerateClusterPhylos {
       exit 0
     fi
 
-    iqtree -s ska.variants.aln
-    mv ska.variants.aln.treefile phylotree.nwk
+    iqtree -s ska.variants.aln 2>&1 | tee iqtree-out
+    
+    # This error means the samples were too divergent, we should treat this like other divergent errors
+    #   The output file will not be present if this error prints so it should not be moved
+    if ! [[ $(grep 'ERROR: Some sequences (see above) are problematic, please check your alignment again' iqtree-out) ]]; then
+      mv ska.variants.aln.treefile phylotree.nwk
+    fi
     >>>
 
     output {


### PR DESCRIPTION
This specific error causes `iqtree` to produce no output so the `mv` command fails even though `iqtree` doesn't exit with an error code. If this error message is produced I will skip the `mv` because we want to ignore this.