### PR TITLE
Fix STAR status upload

### DIFF
--- a/short-read-mngs/host_filter.wdl
+++ b/short-read-mngs/host_filter.wdl
@@ -45,7 +45,8 @@ task RunStar {
     String genome_dir = "STAR_genome/part-0/"
   }
   command<<<
-  # --step-name ryan-test
+  # this comment is for the miniwdl plugin uploader to parse:
+  # --step-name star_out 
   set -euxo pipefail
 
   python3 <<CODE

--- a/short-read-mngs/host_filter.wdl
+++ b/short-read-mngs/host_filter.wdl
@@ -45,6 +45,7 @@ task RunStar {
     String genome_dir = "STAR_genome/part-0/"
   }
   command<<<
+  # --step-name ryan-test
   set -euxo pipefail
 
   python3 <<CODE


### PR DESCRIPTION
Adding a comment in with the `--step-name` allows the miniwdl upload plugin to parse the step name, and upload the status to S3. We should probably rethink how we do this in the future.
