### PR TITLE
replace python script with seqkit (Go)

### DIFF
--- a/consensus-genome/Dockerfile
+++ b/consensus-genome/Dockerfile
@@ -116,3 +116,6 @@ RUN pip3 install taxoniq==0.6.0 && \
     https://github.com/chanzuckerberg/taxoniq/releases/download/v0.6.0/ncbi_genbank_accession_db-2021.4.10-py3-none-any.whl \
     https://github.com/chanzuckerberg/taxoniq/releases/download/v0.6.0/ncbi_genbank_accession_lengths-2021.4.10-py3-none-any.whl \
     https://github.com/chanzuckerberg/taxoniq/releases/download/v0.6.0/ncbi_genbank_accession_offsets-2021.4.10-py3-none-any.whl
+
+RUN wget https://github.com/shenwei356/seqkit/releases/download/v2.0.0/seqkit_linux_amd64.tar.gz && tar zxvf seqkit_linux_amd64.tar.gz \
+&& mv seqkit /usr/local/bin/ && rm seqkit_linux_amd64.tar.gz

--- a/consensus-genome/run.wdl
+++ b/consensus-genome/run.wdl
@@ -343,6 +343,7 @@ task ValidateInput{
 
     output {
         Array[File]+ validated_fastqs = glob("~{prefix}validated*.fastq.gz")
+        File? input_stats = "input_stats.tsv"
     }
 
     runtime {

--- a/consensus-genome/test/test_wdl.py
+++ b/consensus-genome/test/test_wdl.py
@@ -256,6 +256,8 @@ class TestConsensusGenomes(WDLTestCase):
         )
         for output_name, output in res["outputs"].items():
             for filename in output:
+                if output_name == 'ValidateInput.input_stats':
+                    continue
                 self.assertTrue(filename.endswith(".fastq.gz"))
                 self.assertGreater(os.path.getsize(filename), 0)
 


### PR DESCRIPTION
The performance here should be greatly improved. On a test dataset (1.4GB), the step took 1m26s compared to 43m27s. 

Still need to do some testing on seqkit's error conditions. @katrinakalantar do you think we may have any issues with using seqkit? I'm mainly concerned that it may be more restrictive than previous validation steps that we have had. 