### PR TITLE
fix STAR known errors by printing error JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ In addition, if a modification is made that may affect the results of a pipeline
 
 ### Unreleased
 
+### short-read-mngs-v6.8.7
+- fix bug in RunSTAR that caused known errors not to be reported
+
 ### consensus-genome-v3.4.4
 - raise limit for illumina CGs to 500 basepairs
 

--- a/short-read-mngs/host_filter.wdl
+++ b/short-read-mngs/host_filter.wdl
@@ -53,9 +53,14 @@ task RunStar {
   python3 <<CODE
   """ save description to file """
   from idseq_utils.save_descriptions import star_description
-  description = star_description("~{nucleotide_type}")
-  with open("star_out.description.md", "w+") as f:
-    f.write(description)
+  from idseq_utils.exceptions import print_exceptions
+
+  def main():
+    description = star_description("~{nucleotide_type}")
+    with open("star_out.description.md", "w+") as f:
+      f.write(description)
+
+  print_exceptions(main)
   CODE
 
   mkdir "STAR_genome"
@@ -115,15 +120,20 @@ task RunStar {
   import idseq_utils.sync_pairs as sp
   import shutil
   import glob
-  unmapped = sorted(glob.glob("Unmapped.out.mate*"))
-  output_files, too_discrepant = sp.sync_pairs(unmapped)
-  if too_discrepant:
-      raise ValueError("pairs are too discrepant")
-  for unmapped_file in output_files:
-      sp.sort_fastx_by_entry_id(unmapped_file)
+  from idseq_utils.exceptions import print_exceptions
+  
+  def main():
+    unmapped = sorted(glob.glob("Unmapped.out.mate*"))
+    output_files, too_discrepant = sp.sync_pairs(unmapped)
+    if too_discrepant:
+        raise ValueError("pairs are too discrepant")
+    for unmapped_file in output_files:
+        sp.sort_fastx_by_entry_id(unmapped_file)
 
-  for ind, unmapped_file in enumerate(output_files):
-      shutil.move(unmapped_file, f"unmapped{ind+1}.fastq")
+    for ind, unmapped_file in enumerate(output_files):
+        shutil.move(unmapped_file, f"unmapped{ind+1}.fastq")
+
+  print_exceptions(main)
   CODE
 
   if [ -f "Aligned.out.bam" ]; then 
@@ -134,8 +144,13 @@ task RunStar {
   """ count reads """
   import idseq_utils.count_reads as cr
   import glob
-  input_files = sorted(glob.glob("unmapped*.fastq"))
-  cr.main("star_out", input_files)
+  from idseq_utils.exceptions import print_exceptions
+
+  def main():
+    input_files = sorted(glob.glob("unmapped*.fastq"))
+    cr.main("star_out", input_files)
+
+  print_exceptions(main)
   CODE
 
   if [ -f "ReadsPerGene.out.tab" ]; then 

--- a/short-read-mngs/idseq_utils/idseq_utils/exceptions.py
+++ b/short-read-mngs/idseq_utils/idseq_utils/exceptions.py
@@ -1,3 +1,6 @@
+import json
+import traceback
+
 class IDseqDagError(Exception):
     def __init__(self, json):
         super().__init__()
@@ -25,3 +28,11 @@ class BrokenReadPairError(InvalidInputFileError):
 
 class InvalidFileFormatError(InvalidInputFileError):
     pass
+
+
+def print_exceptions(f):
+    try:
+        f()
+    except Exception as e:
+        traceback.print_exc()
+        exit(json.dumps(dict(wdl_error_message=True, error=type(e).__name__, cause=str(e))))


### PR DESCRIPTION
In order for the runner script to detect errors they must be printed as JSON as the last line of stderr. Maybe this constraint is not ideal but I think the best way to solve it for now is by printing errors. I took the code from our running of single pipeline steps:

```python
    try:
        if args.step_class == "PipelineStepRunValidateInput":
            count_input_reads(input_files=step_instance.input_files_local,
                              max_fragments=step_instance.additional_attributes["truncate_fragments_to"])

        step_instance.validate_input_files()
        with open(f"{args.step_name}.description.md", "wb") as outfile:
            # write step_description (which subclasses may generate dynamically) to local file
            outfile.write(step_instance.step_description().encode("utf-8"))
        step_instance.run()
        step_instance.count_reads()
        step_instance.save_counts()
    except Exception as e:
        traceback.print_exc()
        exit(json.dumps(dict(wdl_error_message=True, error=type(e).__name__, cause=str(e), step_description_md=step_instance.step_description())))
```

and adapted it for our new utils.