### PR TITLE
Changed default alignment index from 2020-04-20 to 2021-01-22

### DIFF
--- a/short-read-mngs/experimental.wdl
+++ b/short-read-mngs/experimental.wdl
@@ -238,11 +238,11 @@ workflow idseq_experimental {
     File nonhost_fasta_refined_taxid_annot_fasta
     File duplicate_clusters_csv
     String file_ext = "fastq"
-    String index_version = "2020-04-20" # FIXME: vestigial input
-    File nt_db = "s3://idseq-public-references/ncbi-sources/2020-04-20/nt"
-    File nt_loc_db = "s3://idseq-public-references/alignment_data/2020-04-20/nt_loc.db"
-    File nt_info_db = "s3://idseq-public-references/alignment_data/2020-04-20/nt_info.db"
-    File lineage_db = "s3://idseq-public-references/taxonomy/2020-02-10/taxid-lineages.db"
+    String index_version = "2021-01-22" # FIXME: vestigial input
+    File nt_db = "s3://idseq-public-references/ncbi-sources/2021-01-22/nt"
+    File nt_loc_db = "s3://idseq-public-references/alignment_data/2021-01-22/nt_loc.db"
+    File nt_info_db = "s3://idseq-public-references/alignment_data/2021-01-22/nt_info.db"
+    File lineage_db = "s3://idseq-public-references/taxonomy/2021-01-22/taxid-lineages.db"
     File resist_genome_db = "s3://idseq-public-references/amr/ARGannot_r2.fasta"
     File resist_genome_bed = "s3://idseq-public-references/amr/argannot_genome.bed"
     Boolean use_taxon_whitelist = false

--- a/short-read-mngs/non_host_alignment.wdl
+++ b/short-read-mngs/non_host_alignment.wdl
@@ -157,12 +157,12 @@ workflow idseq_non_host_alignment {
     File? host_filter_out_gsnap_filter_merged_fa
     File duplicate_cluster_sizes_tsv
     File idseq_dedup_out_duplicate_clusters_csv
-    String index_version = "2020-04-20"
-    File lineage_db = "s3://idseq-public-references/taxonomy/2020-04-20/taxid-lineages.db"
-    File accession2taxid_db = "s3://idseq-public-references/alignment_data/2020-04-20/accession2taxid.db"
-    File taxon_blacklist = "s3://idseq-public-references/taxonomy/2020-04-20/taxon_blacklist.txt"
+    String index_version = "2021-01-22"
+    File lineage_db = "s3://idseq-public-references/taxonomy/2021-01-22/taxid-lineages.db"
+    File accession2taxid_db = "s3://idseq-public-references/alignment_data/2021-01-22/accession2taxid.db"
+    File taxon_blacklist = "s3://idseq-public-references/taxonomy/2021-01-22/taxon_blacklist.txt"
     String index_dir_suffix = index_version
-    File deuterostome_db = "s3://idseq-public-references/taxonomy/2020-04-20/deuterostome_taxids.txt"
+    File deuterostome_db = "s3://idseq-public-references/taxonomy/2021-01-22/deuterostome_taxids.txt"
     Boolean use_deuterostome_filter = true
     Boolean use_taxon_whitelist = false
     File? local_gsnap_index

--- a/short-read-mngs/postprocess.wdl
+++ b/short-read-mngs/postprocess.wdl
@@ -471,14 +471,14 @@ workflow idseq_postprocess {
     File rapsearch2_out_rapsearch2_counts_with_dcr_json
     File duplicate_cluster_sizes_tsv
     File idseq_dedup_out_duplicate_clusters_csv
-    String index_version = "2020-04-20" # FIXME: vestigial input
-    File nt_db = "s3://idseq-public-references/ncbi-sources/2020-04-20/nt"
-    File nt_loc_db = "s3://idseq-public-references/alignment_data/2020-04-20/nt_loc.db"
-    File nr_db = "s3://idseq-public-references/ncbi-sources/2020-04-20/nr"
-    File nr_loc_db = "s3://idseq-public-references/alignment_data/2020-04-20/nr_loc.db"
-    File lineage_db = "s3://idseq-public-references/taxonomy/2020-04-20/taxid-lineages.db"
-    File taxon_blacklist = "s3://idseq-public-references/taxonomy/2020-04-20/taxon_blacklist.txt"
-    File deuterostome_db = "s3://idseq-public-references/taxonomy/2020-04-20/deuterostome_taxids.txt"
+    String index_version = "2021-01-22" # FIXME: vestigial input
+    File nt_db = "s3://idseq-public-references/ncbi-sources/2021-01-22/nt"
+    File nt_loc_db = "s3://idseq-public-references/alignment_data/2021-01-22/nt_loc.db"
+    File nr_db = "s3://idseq-public-references/ncbi-sources/2021-01-22/nr"
+    File nr_loc_db = "s3://idseq-public-references/alignment_data/2021-01-22/nr_loc.db"
+    File lineage_db = "s3://idseq-public-references/taxonomy/2021-01-22/taxid-lineages.db"
+    File taxon_blacklist = "s3://idseq-public-references/taxonomy/2021-01-22/taxon_blacklist.txt"
+    File deuterostome_db = "s3://idseq-public-references/taxonomy/2021-01-22/deuterostome_taxids.txt"
     Boolean use_deuterostome_filter = true
     Boolean use_taxon_whitelist = false
     Int min_contig_length = 100


### PR DESCRIPTION
In experimental, one of the links was set to "2020-02-10". I updated it because I didn't see any reason for it to be held back, but can change it back if there is a reason. 