### PR TITLE
Fix test when using the 2021-01-22 version of the NT/NR

### DIFF
--- a/short-read-mngs/test/test_short_read_mngs.py
+++ b/short-read-mngs/test/test_short_read_mngs.py
@@ -29,7 +29,7 @@ def test_bench3_viral(short_read_mngs_bench3_viral_outputs):
         taxon_counts = json.load(infile)["pipeline_output"]["taxon_counts_attributes"]
 
     taxa = set(entry["tax_id"] for entry in taxon_counts)
-    assert abs(len(taxa) - 149) < 5
+    assert abs(len(taxa) - 156) < 5
 
     for filename in outp["outputs"]:
         if filename.endswith(".fasta"):


### PR DESCRIPTION
The short-read-mngs test has more hits when running with the newer version of NT/NR. 